### PR TITLE
3 feat 프로필 관리 기능 api 구현

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/controller/AuthController.java
@@ -1,12 +1,12 @@
-package com.techeer.carpool.domain.member.controller;
+package com.techeer.carpool.domain.auth.controller;
 
-import com.techeer.carpool.domain.member.dto.AuthTokens;
-import com.techeer.carpool.domain.member.dto.LoginRequest;
-import com.techeer.carpool.domain.member.dto.SignupRequest;
-import com.techeer.carpool.domain.member.dto.TokenResponse;
-import com.techeer.carpool.domain.member.service.MemberLoginService;
-import com.techeer.carpool.domain.member.service.MemberSignupService;
-import com.techeer.carpool.domain.member.service.TokenReissueService;
+import com.techeer.carpool.domain.auth.dto.AuthTokens;
+import com.techeer.carpool.domain.auth.dto.LoginRequest;
+import com.techeer.carpool.domain.auth.dto.SignupRequest;
+import com.techeer.carpool.domain.auth.dto.TokenResponse;
+import com.techeer.carpool.domain.auth.service.MemberLoginService;
+import com.techeer.carpool.domain.auth.service.MemberSignupService;
+import com.techeer.carpool.domain.auth.service.TokenReissueService;
 import com.techeer.carpool.global.common.ApiResponse;
 import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/dto/AuthTokens.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/dto/AuthTokens.java
@@ -1,3 +1,3 @@
-package com.techeer.carpool.domain.member.dto;
+package com.techeer.carpool.domain.auth.dto;
 
 public record AuthTokens(String accessToken, String refreshToken) {}

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.techeer.carpool.domain.member.dto;
+package com.techeer.carpool.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/dto/SignupRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/dto/SignupRequest.java
@@ -1,4 +1,4 @@
-package com.techeer.carpool.domain.member.dto;
+package com.techeer.carpool.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/dto/TokenResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/dto/TokenResponse.java
@@ -1,4 +1,4 @@
-package com.techeer.carpool.domain.member.dto;
+package com.techeer.carpool.domain.auth.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/entity/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.techeer.carpool.domain.member.entity;
+package com.techeer.carpool.domain.auth.entity;
 
 import jakarta.persistence.*;
 import lombok.Builder;

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/repository/RefreshTokenRepository.java
@@ -1,6 +1,6 @@
-package com.techeer.carpool.domain.member.repository;
+package com.techeer.carpool.domain.auth.repository;
 
-import com.techeer.carpool.domain.member.entity.RefreshToken;
+import com.techeer.carpool.domain.auth.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/service/MemberLoginService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/service/MemberLoginService.java
@@ -1,11 +1,11 @@
-package com.techeer.carpool.domain.member.service;
+package com.techeer.carpool.domain.auth.service;
 
-import com.techeer.carpool.domain.member.dto.AuthTokens;
-import com.techeer.carpool.domain.member.dto.LoginRequest;
+import com.techeer.carpool.domain.auth.dto.AuthTokens;
+import com.techeer.carpool.domain.auth.dto.LoginRequest;
+import com.techeer.carpool.domain.auth.entity.RefreshToken;
+import com.techeer.carpool.domain.auth.repository.RefreshTokenRepository;
 import com.techeer.carpool.domain.member.entity.Member;
-import com.techeer.carpool.domain.member.entity.RefreshToken;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
-import com.techeer.carpool.domain.member.repository.RefreshTokenRepository;
 import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.jwt.JwtTokenProvider;

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/service/MemberSignupService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/service/MemberSignupService.java
@@ -1,6 +1,6 @@
-package com.techeer.carpool.domain.member.service;
+package com.techeer.carpool.domain.auth.service;
 
-import com.techeer.carpool.domain.member.dto.SignupRequest;
+import com.techeer.carpool.domain.auth.dto.SignupRequest;
 import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.global.exception.CarpoolException;

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/service/TokenReissueService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/service/TokenReissueService.java
@@ -1,8 +1,8 @@
-package com.techeer.carpool.domain.member.service;
+package com.techeer.carpool.domain.auth.service;
 
-import com.techeer.carpool.domain.member.dto.AuthTokens;
-import com.techeer.carpool.domain.member.entity.RefreshToken;
-import com.techeer.carpool.domain.member.repository.RefreshTokenRepository;
+import com.techeer.carpool.domain.auth.dto.AuthTokens;
+import com.techeer.carpool.domain.auth.entity.RefreshToken;
+import com.techeer.carpool.domain.auth.repository.RefreshTokenRepository;
 import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.jwt.JwtTokenProvider;

--- a/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
@@ -1,0 +1,35 @@
+package com.techeer.carpool.domain.member.controller;
+
+import com.techeer.carpool.domain.member.dto.ProfileResponse;
+import com.techeer.carpool.domain.member.dto.ProfileUpdateRequest;
+import com.techeer.carpool.domain.member.service.MemberProfileService;
+import com.techeer.carpool.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberProfileService memberProfileService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<ProfileResponse>> getProfile(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        ProfileResponse profile = memberProfileService.getProfile(memberId);
+        return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<ApiResponse<ProfileResponse>> updateProfile(
+            @Valid @RequestBody ProfileUpdateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        ProfileResponse profile = memberProfileService.updateProfile(memberId, request);
+        return ResponseEntity.ok(ApiResponse.of("프로필이 수정되었습니다.", profile));
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
@@ -17,6 +17,12 @@ public class MemberController {
 
     private final MemberProfileService memberProfileService;
 
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ProfileResponse>> getProfileById(@PathVariable Long id) {
+        ProfileResponse profile = memberProfileService.getProfile(id);
+        return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
+    }
+
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<ProfileResponse>> getProfile(Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();

--- a/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileResponse.java
@@ -1,0 +1,26 @@
+package com.techeer.carpool.domain.member.dto;
+
+import com.techeer.carpool.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ProfileResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private LocalDateTime createdAt;
+
+    public static ProfileResponse from(Member member) {
+        return ProfileResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.techeer.carpool.domain.member.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ProfileUpdateRequest {
+
+    @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
+    private String nickname;
+
+    private String currentPassword;
+
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    private String newPassword;
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/entity/Member.java
@@ -56,6 +56,14 @@ public class Member {
         this.nickname = nickname;
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
     public void withdraw() {
         this.deleted = true;
     }

--- a/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberProfileService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberProfileService.java
@@ -1,0 +1,46 @@
+package com.techeer.carpool.domain.member.service;
+
+import com.techeer.carpool.domain.member.dto.ProfileResponse;
+import com.techeer.carpool.domain.member.dto.ProfileUpdateRequest;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberProfileService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public ProfileResponse getProfile(Long memberId) {
+        Member member = memberRepository.findByIdAndDeletedFalse(memberId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.MEMBER_NOT_FOUND));
+        return ProfileResponse.from(member);
+    }
+
+    @Transactional
+    public ProfileResponse updateProfile(Long memberId, ProfileUpdateRequest request) {
+        Member member = memberRepository.findByIdAndDeletedFalse(memberId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (request.getNickname() != null) {
+            member.updateNickname(request.getNickname());
+        }
+
+        if (request.getNewPassword() != null) {
+            if (request.getCurrentPassword() == null ||
+                    !passwordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
+                throw new CarpoolException(ErrorCode.INVALID_CREDENTIALS);
+            }
+            member.updatePassword(passwordEncoder.encode(request.getNewPassword()));
+        }
+
+        return ProfileResponse.from(member);
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberWithdrawService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberWithdrawService.java
@@ -1,0 +1,27 @@
+package com.techeer.carpool.domain.member.service;
+
+import com.techeer.carpool.domain.auth.repository.RefreshTokenRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberWithdrawService {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void withdraw(Long memberId) {
+        Member member = memberRepository.findByIdAndDeletedFalse(memberId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.MEMBER_NOT_FOUND));
+
+        member.withdraw();
+        refreshTokenRepository.deleteByMemberId(memberId);
+    }
+}


### PR DESCRIPTION
📝 작업 내용

  리팩토링

  기존 domain/member에 인증 코드와 회원 코드가 혼재되어 있던 구조를 개선했습니다.
  인증 관련 코드(로그인, 회원가입, 토큰 재발급)를 domain/auth로 분리하여 각 도메인의 책임을 명확히
  했습니다.

  신규 API

  프로필 조회 및 수정 API를 구현했습니다. 모든 엔드포인트는 JWT 인증이 필요합니다.

  ┌────────┬──────────────────────┬───────────────────────┐
  │ Method │       Endpoint       │         설명          │
  ├────────┼──────────────────────┼───────────────────────┤
  │ GET    │ /api/v1/members/{id} │ 유저 ID로 프로필 조회 │
  ├────────┼──────────────────────┼───────────────────────┤
  │ GET    │ /api/v1/members/me   │ 내 프로필 조회        │
  ├────────┼──────────────────────┼───────────────────────┤
  │ PUT    │ /api/v1/members/me   │ 내 프로필 수정        │
  └────────┴──────────────────────┴───────────────────────┘

  프로필 수정 시 닉네임과 비밀번호를 변경할 수 있으며, 비밀번호 변경 시 현재 비밀번호 검증을 거칩니다.

  ✅ 체크리스트

  - 프로필 조회 API
  - 프로필 수정 API
  - 유저 ID로 프로필 조회 API

  🔗 관련 이슈

  closes #3

  ---