### PR TITLE
refactor: BaseEntity 추상 클래스 도입 및 엔티티 리팩토링

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/entity/Member.java
@@ -42,6 +42,7 @@ public class Member extends SoftDeletableEntity {
         this.password = encodedPassword;
     }
 
+    // 탈퇴 관련 로직 추가를 위해 유지
     public void withdraw() {
         delete();
     }

--- a/backend/src/main/java/com/techeer/carpool/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/entity/Member.java
@@ -1,11 +1,10 @@
 package com.techeer.carpool.domain.member.entity;
 
+import com.techeer.carpool.global.common.entity.SoftDeletableEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -13,7 +12,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "members")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Member {
+public class Member extends SoftDeletableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,32 +21,11 @@ public class Member {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 60)
     private String password;
 
     @Column(nullable = false, length = 50)
     private String nickname;
-
-    @Column(nullable = false)
-    private boolean deleted;
-
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
-
-    @PrePersist
-    private void prePersist() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-        this.deleted = false;
-    }
-
-    @PreUpdate
-    private void preUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
 
     @Builder
     public Member(String email, String password, String nickname) {
@@ -65,6 +43,6 @@ public class Member {
     }
 
     public void withdraw() {
-        this.deleted = true;
+        delete();
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -1,6 +1,7 @@
 package com.techeer.carpool.domain.post.entity;
 
 import com.techeer.carpool.domain.post.dto.PostUpdateRequest;
+import com.techeer.carpool.global.common.entity.SoftDeletableEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "posts")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Post {
+public class Post extends SoftDeletableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -59,27 +60,10 @@ public class Post {
     @Column(nullable = false)
     private boolean autoAccept;
 
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Column(nullable = false)
-    private boolean deleted;
-
     @PrePersist
     private void prePersist() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
         this.status = PostStatus.OPEN;
         this.currentPassengers = 0;
-        this.deleted = false;
-    }
-
-    @PreUpdate
-    private void preUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 
     @Builder
@@ -115,9 +99,5 @@ public class Post {
         this.description = request.getDescription();
         this.autoAccept = request.isAutoAccept();
         this.status = request.getStatus();
-    }
-
-    public void delete() {
-        this.deleted = true;
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/entity/Ride.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/entity/Ride.java
@@ -1,18 +1,19 @@
 package com.techeer.carpool.domain.ride.entity;
 
+import com.techeer.carpool.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity                          // 이 클래스가 DB 테이블과 매핑되는 JPA 엔티티임을 선언
-@Table(name = "rides")           // DB에서 테이블 이름을 "rides"로 지정
-@Getter                          // Lombok: 모든 필드의 getter 메서드 자동 생성
-@NoArgsConstructor(access = AccessLevel.PROTECTED)  // Lombok: 기본 생성자를 protected로 생성 (외부에서 new Ride() 직접 호출 방지, JPA 내부 사용용)
-@Builder                         // Lombok: 빌더 패턴 자동 생성 (Ride.builder().postId(1L).build() 형태로 객체 생성 가능)
-@AllArgsConstructor              // Lombok: 모든 필드를 받는 생성자 자동 생성 (@Builder가 내부적으로 필요로 함)
-public class Ride {
+@Entity
+@Table(name = "rides")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class Ride extends BaseEntity {
 
     @Id                                                    // 이 필드가 PK(기본키)임을 선언
     @GeneratedValue(strategy = GenerationType.IDENTITY)    // PK를 DB에서 자동 증가(AUTO_INCREMENT)로 생성

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/entity/RidePassenger.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/entity/RidePassenger.java
@@ -1,16 +1,17 @@
 package com.techeer.carpool.domain.ride.entity;
 
+import com.techeer.carpool.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "ride_passengers")  // DB 테이블 이름: "ride_passengers"
+@Table(name = "ride_passengers")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class RidePassenger {
+public class RidePassenger extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/techeer/carpool/global/common/entity/BaseEntity.java
+++ b/backend/src/main/java/com/techeer/carpool/global/common/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.techeer.carpool.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/techeer/carpool/global/common/entity/SoftDeletableEntity.java
+++ b/backend/src/main/java/com/techeer/carpool/global/common/entity/SoftDeletableEntity.java
@@ -1,0 +1,17 @@
+package com.techeer.carpool.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+public abstract class SoftDeletableEntity extends BaseEntity {
+
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    public void delete() {
+        this.deleted = true;
+    }
+}


### PR DESCRIPTION
Closes #23

## 작업 내용

### 추상 클래스 생성 (`global/common/entity/`)

- `BaseEntity`: `@CreationTimestamp`, `@UpdateTimestamp`로 `createdAt`, `updatedAt` 관리
- `SoftDeletableEntity`: `BaseEntity` 상속, `deleted` 필드 및 `delete()` 메서드 포함

### 엔티티 수정

| 엔티티 | 변경 내용 |
|--------|----------|
| `Member` | `SoftDeletableEntity` 상속, 중복 필드/`@PrePersist`/`@PreUpdate` 제거 |
| `Post` | `SoftDeletableEntity` 상속, 중복 필드/타임스탬프 초기화 제거 (`@PrePersist`는 `status`, `currentPassengers` 초기화 용도로 유지) |
| `Ride` | `BaseEntity` 상속, `createdAt`/`updatedAt` 추가 |
| `RidePassenger` | `BaseEntity` 상속, `createdAt`/`updatedAt` 추가 |

### 기타

- `Member.password` 컬럼 `length=60` 명시 (BCrypt 해시 길이)
- `Member.withdraw()` 탈퇴 관련 로직 확장을 위해 유지 (주석 추가)

## 변경 효과

- `createdAt`, `updatedAt`, `deleted` 중복 선언 제거
- 새 엔티티 추가 시 상속만으로 공통 필드 자동 적용
- `@PrePersist`/`@PreUpdate` 보일러플레이트 제거