### PR TITLE
[Security] 게시글 API memberId body 주입 및 소유권 검증 누락 수정

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
@@ -11,6 +11,7 @@ import com.techeer.carpool.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,9 +27,12 @@ public class PostController {
     private final PostDeleteService postDeleteService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<PostResponse>> createPost(@RequestBody PostCreateRequest request) {
+    public ResponseEntity<ApiResponse<PostResponse>> createPost(
+            @RequestBody PostCreateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.of("게시글이 생성되었습니다.", postCreateService.createPost(request)));
+                .body(ApiResponse.of("게시글이 생성되었습니다.", postCreateService.createPost(request, memberId)));
     }
 
     @GetMapping
@@ -42,14 +46,20 @@ public class PostController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<PostResponse>> updatePost(@PathVariable Long id,
-                                                                @RequestBody PostUpdateRequest request) {
-        return ResponseEntity.ok(ApiResponse.of("게시글이 수정되었습니다.", postUpdateService.updatePost(id, request)));
+    public ResponseEntity<ApiResponse<PostResponse>> updatePost(
+            @PathVariable Long id,
+            @RequestBody PostUpdateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("게시글이 수정되었습니다.", postUpdateService.updatePost(id, request, memberId)));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
-        postDeleteService.deletePost(id);
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        postDeleteService.deletePost(id, memberId);
         return ResponseEntity.ok(ApiResponse.of("게시글이 삭제되었습니다."));
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Builder
 public class PostCreateRequest {
 
-    private Long memberId;
     private String title;
     private String departureLocation;
     private Double departureLat;

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
@@ -15,9 +15,9 @@ public class PostCreateService {
     private final PostRepository postRepository;
 
     @Transactional
-    public PostResponse createPost(PostCreateRequest request) {
+    public PostResponse createPost(PostCreateRequest request, Long memberId) {
         Post post = Post.builder()
-                .memberId(request.getMemberId())
+                .memberId(memberId)
                 .title(request.getTitle())
                 .departureLocation(request.getDepartureLocation())
                 .departureLat(request.getDepartureLat())

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostDeleteService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostDeleteService.java
@@ -15,9 +15,12 @@ public class PostDeleteService {
     private final PostRepository postRepository;
 
     @Transactional
-    public void deletePost(Long id) {
+    public void deletePost(Long id, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
+        }
         post.delete();
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
@@ -17,9 +17,12 @@ public class PostUpdateService {
     private final PostRepository postRepository;
 
     @Transactional
-    public PostResponse updatePost(Long id, PostUpdateRequest request) {
+    public PostResponse updatePost(Long id, PostUpdateRequest request, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
+        }
         post.updateFrom(request);
         return PostResponse.from(post);
     }

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     POST_NOT_FOUND("POST_001", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    POST_FORBIDDEN("POST_002", "게시글 수정/삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),


### PR DESCRIPTION
## 관련 이슈
Closes #25

## 변경 사항

### 이슈 1 — memberId body 주입 취약점 수정
- `PostCreateRequest`에서 `memberId` 필드 제거
- `PostController`에서 `Authentication.getPrincipal()`로 JWT에서 memberId 추출
- `PostCreateService` 시그니처 변경: `createPost(request, memberId)`

### 이슈 2 — 수정/삭제 소유권 검증 추가
- `PostDeleteService.deletePost(id, requesterId)` — 요청자와 작성자 비교
- `PostUpdateService.updatePost(id, request, requesterId)` — 동일하게 검증
- 소유권 불일치 시 `POST_FORBIDDEN (POST_002, 403)` 반환
- `ErrorCode`에 `POST_FORBIDDEN` 추가

### 프론트엔드
- `useCarpool.js` — `addPost()`에서 `memberId` 필드 제거 (백엔드가 JWT에서 추출)

## 테스트 체크리스트
- [ ] 본인 글 삭제 → 200
- [ ] 타인 글 삭제 → 403, `"code": "POST_002"`
- [ ] 본인 글 수정 → 200
- [ ] 타인 글 수정 → 403, `"code": "POST_002"`
- [ ] 게시글 생성 → 응답의 `memberId`가 토큰 소유자와 일치