### PR TITLE
[Feature] PostResponse nickname 포함 + Post price/tags 필드 추가

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
@@ -11,6 +11,7 @@ import com.techeer.carpool.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,9 +27,12 @@ public class PostController {
     private final PostDeleteService postDeleteService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<PostResponse>> createPost(@RequestBody PostCreateRequest request) {
+    public ResponseEntity<ApiResponse<PostResponse>> createPost(
+            @RequestBody PostCreateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.of("게시글이 생성되었습니다.", postCreateService.createPost(request)));
+                .body(ApiResponse.of("게시글이 생성되었습니다.", postCreateService.createPost(request, memberId)));
     }
 
     @GetMapping
@@ -42,14 +46,20 @@ public class PostController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<PostResponse>> updatePost(@PathVariable Long id,
-                                                                @RequestBody PostUpdateRequest request) {
-        return ResponseEntity.ok(ApiResponse.of("게시글이 수정되었습니다.", postUpdateService.updatePost(id, request)));
+    public ResponseEntity<ApiResponse<PostResponse>> updatePost(
+            @PathVariable Long id,
+            @RequestBody PostUpdateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("게시글이 수정되었습니다.", postUpdateService.updatePost(id, request, memberId)));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
-        postDeleteService.deletePost(id);
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        postDeleteService.deletePost(id, memberId);
         return ResponseEntity.ok(ApiResponse.of("게시글이 삭제되었습니다."));
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
@@ -14,7 +14,6 @@ import java.util.List;
 @Builder
 public class PostCreateRequest {
 
-    private Long memberId;
     private String title;
     private String departureLocation;
     private Double departureLat;

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -25,4 +26,6 @@ public class PostCreateRequest {
     private int maxPassengers;
     private String description;
     private boolean autoAccept;
+    private Integer price;
+    private List<String> tags;
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -13,6 +14,7 @@ public class PostResponse {
 
     private Long id;
     private Long memberId;
+    private String nickname;
     private String title;
     private String departureLocation;
     private Double departureLat;
@@ -26,13 +28,16 @@ public class PostResponse {
     private PostStatus status;
     private String description;
     private boolean autoAccept;
+    private Integer price;
+    private List<String> tags;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static PostResponse from(Post post) {
+    public static PostResponse from(Post post, String nickname) {
         return PostResponse.builder()
                 .id(post.getId())
                 .memberId(post.getMemberId())
+                .nickname(nickname)
                 .title(post.getTitle())
                 .departureLocation(post.getDepartureLocation())
                 .departureLat(post.getDepartureLat())
@@ -46,6 +51,8 @@ public class PostResponse {
                 .status(post.getStatus())
                 .description(post.getDescription())
                 .autoAccept(post.isAutoAccept())
+                .price(post.getPrice())
+                .tags(post.getTags())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostUpdateRequest.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -26,4 +27,6 @@ public class PostUpdateRequest {
     private String description;
     private boolean autoAccept;
     private PostStatus status;
+    private Integer price;
+    private List<String> tags;
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -59,6 +61,13 @@ public class Post {
     @Column(nullable = false)
     private boolean autoAccept;
 
+    private Integer price;
+
+    @ElementCollection
+    @CollectionTable(name = "post_tags", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "tag")
+    private List<String> tags = new ArrayList<>();
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -87,7 +96,8 @@ public class Post {
                 String departureLocation, Double departureLat, Double departureLng,
                 String destinationLocation, Double destinationLat, Double destinationLng,
                 LocalDateTime departureTime, int maxPassengers,
-                String description, boolean autoAccept) {
+                String description, boolean autoAccept,
+                Integer price, List<String> tags) {
         this.memberId = memberId;
         this.title = title;
         this.departureLocation = departureLocation;
@@ -100,6 +110,8 @@ public class Post {
         this.maxPassengers = maxPassengers;
         this.description = description;
         this.autoAccept = autoAccept;
+        this.price = price;
+        this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
     }
 
     public void updateFrom(PostUpdateRequest request) {
@@ -115,6 +127,8 @@ public class Post {
         this.description = request.getDescription();
         this.autoAccept = request.isAutoAccept();
         this.status = request.getStatus();
+        this.price = request.getPrice();
+        this.tags = request.getTags() != null ? new ArrayList<>(request.getTags()) : new ArrayList<>();
     }
 
     public void delete() {

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -69,15 +69,6 @@ public class Post extends SoftDeletableEntity {
     @Column(name = "tag")
     private List<String> tags = new ArrayList<>();
 
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Column(nullable = false)
-    private boolean deleted;
-
     @PrePersist
     private void prePersist() {
         this.status = PostStatus.OPEN;

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
@@ -1,5 +1,7 @@
 package com.techeer.carpool.domain.post.service;
 
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.dto.PostCreateRequest;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.entity.Post;
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostCreateService {
 
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public PostResponse createPost(PostCreateRequest request) {
@@ -29,8 +32,13 @@ public class PostCreateService {
                 .maxPassengers(request.getMaxPassengers())
                 .description(request.getDescription())
                 .autoAccept(request.isAutoAccept())
+                .price(request.getPrice())
+                .tags(request.getTags())
                 .build();
-
-        return PostResponse.from(postRepository.save(post));
+        Post saved = postRepository.save(post);
+        String nickname = memberRepository.findById(saved.getMemberId())
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return PostResponse.from(saved, nickname);
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
@@ -18,9 +18,9 @@ public class PostCreateService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public PostResponse createPost(PostCreateRequest request) {
+    public PostResponse createPost(PostCreateRequest request, Long memberId) {
         Post post = Post.builder()
-                .memberId(request.getMemberId())
+                .memberId(memberId)
                 .title(request.getTitle())
                 .departureLocation(request.getDepartureLocation())
                 .departureLat(request.getDepartureLat())

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostDeleteService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostDeleteService.java
@@ -15,9 +15,12 @@ public class PostDeleteService {
     private final PostRepository postRepository;
 
     @Transactional
-    public void deletePost(Long id) {
+    public void deletePost(Long id, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
+        }
         post.delete();
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostReadService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostReadService.java
@@ -1,5 +1,7 @@
 package com.techeer.carpool.domain.post.service;
 
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.repository.PostRepository;
@@ -10,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -18,17 +22,24 @@ import java.util.stream.Collectors;
 public class PostReadService {
 
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
     public List<PostResponse> getAllPosts() {
-        return postRepository.findByDeletedFalseOrderByCreatedAtDesc()
-                .stream()
-                .map(PostResponse::from)
+        List<Post> posts = postRepository.findByDeletedFalseOrderByCreatedAtDesc();
+        Set<Long> memberIds = posts.stream().map(Post::getMemberId).collect(Collectors.toSet());
+        Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, Member::getNickname));
+        return posts.stream()
+                .map(p -> PostResponse.from(p, nicknameMap.getOrDefault(p.getMemberId(), "알 수 없음")))
                 .collect(Collectors.toList());
     }
 
     public PostResponse getPostById(Long id) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
-        return PostResponse.from(post);
+        String nickname = memberRepository.findById(post.getMemberId())
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return PostResponse.from(post, nickname);
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
@@ -20,9 +20,12 @@ public class PostUpdateService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public PostResponse updatePost(Long id, PostUpdateRequest request) {
+    public PostResponse updatePost(Long id, PostUpdateRequest request, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
+        }
         post.updateFrom(request);
         String nickname = memberRepository.findById(post.getMemberId())
                 .map(Member::getNickname)

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
@@ -1,5 +1,7 @@
 package com.techeer.carpool.domain.post.service;
 
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.dto.PostUpdateRequest;
 import com.techeer.carpool.domain.post.entity.Post;
@@ -15,12 +17,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostUpdateService {
 
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public PostResponse updatePost(Long id, PostUpdateRequest request) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
         post.updateFrom(request);
-        return PostResponse.from(post);
+        String nickname = memberRepository.findById(post.getMemberId())
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return PostResponse.from(post, nickname);
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     POST_NOT_FOUND("POST_001", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    POST_FORBIDDEN("POST_002", "게시글 수정/삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),


### PR DESCRIPTION
## 관련 이슈
Closes #27

## 변경 사항

### 1. Post 엔티티 — price, tags 추가
- `price`: Integer, nullable (카풀 비용)
- `tags`: `List<String>`, `@ElementCollection` → `post_tags` 테이블 자동 생성
- `PostCreateRequest`, `PostUpdateRequest`, `PostResponse`에 동일하게 반영
- `Post.updateFrom()`에서 price, tags 업데이트 처리

### 2. PostResponse — nickname 포함
- `PostResponse.from(Post, String nickname)` 시그니처 변경
- `PostReadService.getAllPosts()`: memberId Set으로 일괄 조회 → N+1 방지
- `PostReadService.getPostById()`: 단건 조회 후 nickname 포함
- `PostCreateService`, `PostUpdateService`: 응답에 nickname 포함

## 테스트 체크리스트
- [ ] `POST /posts` 응답에 `nickname`, `price`, `tags` 포함 확인
- [ ] `GET /posts` 응답 배열 각 항목에 `nickname` 포함 확인
- [ ] `PUT /posts/{id}` 요청 시 `price`, `tags` 수정 반영 확인
- [ ] 작성자가 탈퇴한 게시글 조회 시 nickname `"알 수 없음"` 처리 확인