### PR TITLE
feat: 댓글(Comment) 도메인 구현 (#29)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/controller/CommentController.java
@@ -1,0 +1,49 @@
+package com.techeer.carpool.domain.comment.controller;
+
+import com.techeer.carpool.domain.comment.dto.CommentCreateRequest;
+import com.techeer.carpool.domain.comment.dto.CommentResponse;
+import com.techeer.carpool.domain.comment.service.CommentCreateService;
+import com.techeer.carpool.domain.comment.service.CommentDeleteService;
+import com.techeer.carpool.domain.comment.service.CommentReadService;
+import com.techeer.carpool.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentCreateService commentCreateService;
+    private final CommentReadService commentReadService;
+    private final CommentDeleteService commentDeleteService;
+
+    @PostMapping("/api/v1/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of("댓글이 작성되었습니다.", commentCreateService.createComment(postId, request, memberId)));
+    }
+
+    @GetMapping("/api/v1/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<List<CommentResponse>>> getComments(@PathVariable Long postId) {
+        return ResponseEntity.ok(ApiResponse.of("댓글 목록 조회 성공", commentReadService.getCommentsByPostId(postId)));
+    }
+
+    @DeleteMapping("/api/v1/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable Long commentId,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        commentDeleteService.deleteComment(commentId, memberId);
+        return ResponseEntity.ok(ApiResponse.of("댓글이 삭제되었습니다."));
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/dto/CommentCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,15 @@
+package com.techeer.carpool.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentCreateRequest {
+
+    @NotBlank(message = "댓글 내용을 입력해주세요.")
+    @Size(max = 500, message = "댓글은 500자 이내로 입력해주세요.")
+    private String content;
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/dto/CommentResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,30 @@
+package com.techeer.carpool.domain.comment.dto;
+
+import com.techeer.carpool.domain.comment.entity.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentResponse {
+
+    private Long id;
+    private Long postId;
+    private Long memberId;
+    private String nickname;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static CommentResponse from(Comment comment, String nickname) {
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .postId(comment.getPostId())
+                .memberId(comment.getMemberId())
+                .nickname(nickname)
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/entity/Comment.java
@@ -1,0 +1,53 @@
+package com.techeer.carpool.domain.comment.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long postId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private boolean deleted;
+
+    @PrePersist
+    private void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.deleted = false;
+    }
+
+    @Builder
+    public Comment(Long postId, Long memberId, String content) {
+        this.postId = postId;
+        this.memberId = memberId;
+        this.content = content;
+    }
+
+    public void delete() {
+        this.deleted = true;
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.techeer.carpool.domain.comment.repository;
+
+import com.techeer.carpool.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByPostIdAndDeletedFalseOrderByCreatedAtAsc(Long postId);
+
+    Optional<Comment> findByIdAndDeletedFalse(Long id);
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentCreateService.java
@@ -1,0 +1,41 @@
+package com.techeer.carpool.domain.comment.service;
+
+import com.techeer.carpool.domain.comment.dto.CommentCreateRequest;
+import com.techeer.carpool.domain.comment.dto.CommentResponse;
+import com.techeer.carpool.domain.comment.entity.Comment;
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCreateService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public CommentResponse createComment(Long postId, CommentCreateRequest request, Long memberId) {
+        postRepository.findByIdAndDeletedFalse(postId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        Comment comment = Comment.builder()
+                .postId(postId)
+                .memberId(memberId)
+                .content(request.getContent())
+                .build();
+
+        Comment saved = commentRepository.save(comment);
+        String nickname = memberRepository.findById(memberId)
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return CommentResponse.from(saved, nickname);
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentDeleteService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentDeleteService.java
@@ -1,0 +1,27 @@
+package com.techeer.carpool.domain.comment.service;
+
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentDeleteService {
+
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void deleteComment(Long commentId, Long memberId) {
+        var comment = commentRepository.findByIdAndDeletedFalse(commentId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getMemberId().equals(memberId)) {
+            throw new CarpoolException(ErrorCode.COMMENT_FORBIDDEN);
+        }
+
+        comment.delete();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentReadService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentReadService.java
@@ -1,0 +1,46 @@
+package com.techeer.carpool.domain.comment.service;
+
+import com.techeer.carpool.domain.comment.dto.CommentResponse;
+import com.techeer.carpool.domain.comment.entity.Comment;
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReadService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentsByPostId(Long postId) {
+        postRepository.findByIdAndDeletedFalse(postId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        List<Comment> comments = commentRepository.findByPostIdAndDeletedFalseOrderByCreatedAtAsc(postId);
+
+        Set<Long> memberIds = comments.stream()
+                .map(Comment::getMemberId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, Member::getNickname));
+
+        return comments.stream()
+                .map(c -> CommentResponse.from(c, nicknameMap.getOrDefault(c.getMemberId(), "알 수 없음")))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -6,6 +6,8 @@ public enum ErrorCode {
 
     POST_NOT_FOUND("POST_001", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     POST_FORBIDDEN("POST_002", "게시글 수정/삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    COMMENT_NOT_FOUND("COMMENT_001", "댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_FORBIDDEN("COMMENT_002", "댓글 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     POST_NOT_FOUND("POST_001", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_NOT_FOUND("COMMENT_001", "댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_FORBIDDEN("COMMENT_002", "댓글 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -1,13 +1,20 @@
 package com.techeer.carpool.global.init;
 
+import com.techeer.carpool.domain.comment.entity.Comment;
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
 import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Profile("local")
@@ -16,22 +23,91 @@ import org.springframework.stereotype.Component;
 public class LocalDataInitializer implements CommandLineRunner {
 
     private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
     public void run(String... args) {
-        createIfNotExists("test@carpool.com", "password1234", "테스트유저");
-        createIfNotExists("admin@carpool.com", "admin1234!", "관리자");
-        log.info("[LocalDataInitializer] 테스트 계정 생성 완료");
+        Member test  = createMemberIfNotExists("test@carpool.com",  "password1234", "테스트유저");
+        Member admin = createMemberIfNotExists("admin@carpool.com", "admin1234!",   "관리자");
+
+        if (postRepository.findByDeletedFalseOrderByCreatedAtDesc().isEmpty()) {
+            seedPosts(test, admin);
+        }
+
+        log.info("[LocalDataInitializer] 초기 데이터 생성 완료");
     }
 
-    private void createIfNotExists(String email, String password, String nickname) {
-        if (!memberRepository.existsByEmail(email)) {
-            memberRepository.save(Member.builder()
-                    .email(email)
-                    .password(passwordEncoder.encode(password))
-                    .nickname(nickname)
-                    .build());
-        }
+    private void seedPosts(Member test, Member admin) {
+        Post p1 = postRepository.save(Post.builder()
+                .memberId(admin.getId())
+                .title("강남역 → 판교역")
+                .departureLocation("강남역")
+                .departureLat(37.4979).departureLng(127.0276)
+                .destinationLocation("판교역")
+                .destinationLat(37.3943).destinationLng(127.1110)
+                .departureTime(LocalDateTime.now().plusDays(1).withHour(8).withMinute(30).withSecond(0).withNano(0))
+                .maxPassengers(3)
+                .description("정시 출발합니다. 짐 많으신 분은 미리 말씀해 주세요.")
+                .autoAccept(false)
+                .build());
+
+        Post p2 = postRepository.save(Post.builder()
+                .memberId(test.getId())
+                .title("홍대입구 → 여의도역")
+                .departureLocation("홍대입구")
+                .departureLat(37.5572).departureLng(126.9247)
+                .destinationLocation("여의도역")
+                .destinationLat(37.5215).destinationLng(126.9242)
+                .departureTime(LocalDateTime.now().plusDays(2).withHour(9).withMinute(0).withSecond(0).withNano(0))
+                .maxPassengers(2)
+                .description("경유지 없이 직행입니다.")
+                .autoAccept(true)
+                .build());
+
+        Post p3 = postRepository.save(Post.builder()
+                .memberId(admin.getId())
+                .title("서울역 → 수원역")
+                .departureLocation("서울역")
+                .departureLat(37.5547).departureLng(126.9707)
+                .destinationLocation("수원역")
+                .destinationLat(37.2664).destinationLng(127.0003)
+                .departureTime(LocalDateTime.now().plusDays(3).withHour(7).withMinute(0).withSecond(0).withNano(0))
+                .maxPassengers(4)
+                .description("반드시 제시간에 탑승 부탁드립니다.")
+                .autoAccept(false)
+                .build());
+
+        seedComments(p1, test, admin);
+        seedComments(p2, admin, test);
+        seedComments(p3, test, admin);
+    }
+
+    private void seedComments(Post post, Member first, Member second) {
+        commentRepository.save(Comment.builder()
+                .postId(post.getId())
+                .memberId(first.getId())
+                .content("저도 같은 방향이에요! 탑승 가능할까요?")
+                .build());
+        commentRepository.save(Comment.builder()
+                .postId(post.getId())
+                .memberId(second.getId())
+                .content("몇 시쯤 도착 예정인가요?")
+                .build());
+        commentRepository.save(Comment.builder()
+                .postId(post.getId())
+                .memberId(first.getId())
+                .content("좋아요, 당일 아침에 다시 연락 드릴게요 :)")
+                .build());
+    }
+
+    private Member createMemberIfNotExists(String email, String password, String nickname) {
+        return memberRepository.findByEmail(email).orElseGet(() ->
+                memberRepository.save(Member.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode(password))
+                        .nickname(nickname)
+                        .build()));
     }
 }

--- a/backend/src/test/java/com/techeer/carpool/domain/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/comment/CommentIntegrationTest.java
@@ -1,0 +1,168 @@
+package com.techeer.carpool.domain.comment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.carpool.domain.comment.dto.CommentCreateRequest;
+import com.techeer.carpool.domain.comment.entity.Comment;
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CommentIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired CommentRepository commentRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+
+    private Long memberId;
+    private Long otherMemberId;
+    private Long postId;
+    private String token;
+    private String otherToken;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository.deleteAll();
+        postRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        Member member = memberRepository.save(Member.builder()
+                .email("test@test.com")
+                .password("password")
+                .nickname("테스터")
+                .build());
+        memberId = member.getId();
+        token = "Bearer " + jwtTokenProvider.createAccessToken(memberId);
+
+        Member other = memberRepository.save(Member.builder()
+                .email("other@test.com")
+                .password("password")
+                .nickname("다른유저")
+                .build());
+        otherMemberId = other.getId();
+        otherToken = "Bearer " + jwtTokenProvider.createAccessToken(otherMemberId);
+
+        Post post = postRepository.save(Post.builder()
+                .memberId(memberId)
+                .title("테스트 카풀")
+                .departureLocation("강남역")
+                .destinationLocation("판교역")
+                .departureTime(LocalDateTime.now().plusDays(1))
+                .maxPassengers(3)
+                .description("테스트")
+                .autoAccept(false)
+                .build());
+        postId = post.getId();
+    }
+
+    @Test
+    @DisplayName("댓글 작성 성공")
+    void createComment_success() throws Exception {
+        CommentCreateRequest request = new CommentCreateRequest();
+        setField(request, "content", "탑승 신청합니다!");
+
+        mockMvc.perform(post("/api/v1/posts/{postId}/comments", postId)
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.content").value("탑승 신청합니다!"))
+                .andExpect(jsonPath("$.data.nickname").value("테스터"))
+                .andExpect(jsonPath("$.data.postId").value(postId));
+    }
+
+    @Test
+    @DisplayName("댓글 목록 조회 성공")
+    void getComments_success() throws Exception {
+        commentRepository.save(Comment.builder()
+                .postId(postId).memberId(memberId).content("첫 번째 댓글").build());
+        commentRepository.save(Comment.builder()
+                .postId(postId).memberId(memberId).content("두 번째 댓글").build());
+
+        mockMvc.perform(get("/api/v1/posts/{postId}/comments", postId)
+                        .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].content").value("첫 번째 댓글"))
+                .andExpect(jsonPath("$.data[1].content").value("두 번째 댓글"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글에 댓글 작성 시 404")
+    void createComment_postNotFound() throws Exception {
+        CommentCreateRequest request = new CommentCreateRequest();
+        setField(request, "content", "댓글");
+
+        mockMvc.perform(post("/api/v1/posts/{postId}/comments", 999L)
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_001"));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공 - 본인")
+    void deleteComment_success() throws Exception {
+        Comment comment = commentRepository.save(Comment.builder()
+                .postId(postId).memberId(memberId).content("삭제될 댓글").build());
+
+        mockMvc.perform(delete("/api/v1/comments/{commentId}", comment.getId())
+                        .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("댓글이 삭제되었습니다."));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 실패 - 타인")
+    void deleteComment_forbidden() throws Exception {
+        Comment comment = commentRepository.save(Comment.builder()
+                .postId(postId).memberId(memberId).content("남의 댓글").build());
+
+        mockMvc.perform(delete("/api/v1/comments/{commentId}", comment.getId())
+                        .header("Authorization", otherToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMENT_002"));
+    }
+
+    @Test
+    @DisplayName("빈 내용으로 댓글 작성 시 400")
+    void createComment_emptyContent() throws Exception {
+        CommentCreateRequest request = new CommentCreateRequest();
+        setField(request, "content", "");
+
+        mockMvc.perform(post("/api/v1/posts/{postId}/comments", postId)
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    private void setField(Object obj, String fieldName, Object value) throws Exception {
+        var field = obj.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+}


### PR DESCRIPTION
## Summary

- Comment 엔티티 추가 (`id`, `postId`, `memberId`, `content`, `createdAt`, 소프트 딜리트)
- `CommentCreateRequest` / `CommentResponse` DTO 추가 (nickname 포함)
- `CommentRepository` 추가 (postId 기준 조회, 소프트 딜리트 필터)
- `COMMENT_001` / `COMMENT_002` ErrorCode 추가
- `CommentCreateService` / `CommentReadService` / `CommentDeleteService` 추가
- `CommentController` 추가 — `POST/GET /api/v1/posts/{postId}/comments`, `DELETE /api/v1/comments/{id}`
- 통합 테스트 5건 추가 (작성 성공, 목록 조회, 404, 삭제 성공, 403)

## API

| Method | Path | 인증 | 설명 |
|---|---|---|---|
| POST | `/api/v1/posts/{postId}/comments` | ✅ | 댓글 작성 |
| GET | `/api/v1/posts/{postId}/comments` | ✅ | 댓글 목록 조회 |
| DELETE | `/api/v1/comments/{commentId}` | ✅ | 댓글 삭제 (본인만) |

## Test plan

- [x] 댓글 작성 성공 (201, nickname 포함)
- [x] 댓글 목록 조회 성공 (200, 생성순 정렬)
- [x] 존재하지 않는 게시글에 댓글 작성 → POST_001 (404)
- [x] 본인 댓글 삭제 성공 (200)
- [x] 타인 댓글 삭제 시 COMMENT_002 (403)
- [x] 빈 내용 작성 시 400

Closes #29