### PR TITLE
feat: 카풀 신청(Application) 도메인 구현 (#33)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,31 +18,26 @@ repositories {
 }
 
 dependencies {
-	//env 의존성
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 
-	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	runtimeOnly 'org.postgresql:postgresql'
 
-	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-webmvc-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'

--- a/backend/src/main/java/com/techeer/carpool/domain/application/controller/ApplicationController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/controller/ApplicationController.java
@@ -1,0 +1,63 @@
+package com.techeer.carpool.domain.application.controller;
+
+import com.techeer.carpool.domain.application.dto.ApplicationResponse;
+import com.techeer.carpool.domain.application.service.ApplicationCreateService;
+import com.techeer.carpool.domain.application.service.ApplicationReadService;
+import com.techeer.carpool.domain.application.service.ApplicationStatusService;
+import com.techeer.carpool.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ApplicationController {
+
+    private final ApplicationCreateService applicationCreateService;
+    private final ApplicationReadService applicationReadService;
+    private final ApplicationStatusService applicationStatusService;
+
+    @PostMapping("/api/v1/posts/{postId}/applications")
+    public ResponseEntity<ApiResponse<ApplicationResponse>> apply(
+            @PathVariable Long postId,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of("카풀 신청이 완료되었습니다.", applicationCreateService.apply(postId, memberId)));
+    }
+
+    @GetMapping("/api/v1/applications/me")
+    public ResponseEntity<ApiResponse<List<ApplicationResponse>>> getMyApplications(
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("내 신청 내역 조회 성공", applicationReadService.getMyApplications(memberId)));
+    }
+
+    @GetMapping("/api/v1/posts/{postId}/applications")
+    public ResponseEntity<ApiResponse<List<ApplicationResponse>>> getApplicationsByPost(
+            @PathVariable Long postId,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("신청 목록 조회 성공", applicationReadService.getApplicationsByPost(postId, memberId)));
+    }
+
+    @PatchMapping("/api/v1/applications/{id}/accept")
+    public ResponseEntity<ApiResponse<ApplicationResponse>> accept(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("신청을 수락했습니다.", applicationStatusService.accept(id, memberId)));
+    }
+
+    @PatchMapping("/api/v1/applications/{id}/reject")
+    public ResponseEntity<ApiResponse<ApplicationResponse>> reject(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("신청을 거절했습니다.", applicationStatusService.reject(id, memberId)));
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/application/dto/ApplicationResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/dto/ApplicationResponse.java
@@ -1,0 +1,31 @@
+package com.techeer.carpool.domain.application.dto;
+
+import com.techeer.carpool.domain.application.entity.Application;
+import com.techeer.carpool.domain.application.entity.ApplicationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ApplicationResponse {
+
+    private Long id;
+    private Long postId;
+    private Long applicantId;
+    private String applicantNickname;
+    private ApplicationStatus status;
+    private LocalDateTime createdAt;
+
+    public static ApplicationResponse of(Application application, String nickname) {
+        return ApplicationResponse.builder()
+                .id(application.getId())
+                .postId(application.getPostId())
+                .applicantId(application.getApplicantId())
+                .applicantNickname(nickname)
+                .status(application.getStatus())
+                .createdAt(application.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/application/entity/Application.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/entity/Application.java
@@ -1,0 +1,47 @@
+package com.techeer.carpool.domain.application.entity;
+
+import com.techeer.carpool.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(
+    name = "applications",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "applicant_id"})
+)
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Application extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Column(name = "applicant_id", nullable = false)
+    private Long applicantId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ApplicationStatus status = ApplicationStatus.PENDING;
+
+    @Builder
+    public Application(Long postId, Long applicantId) {
+        this.postId = postId;
+        this.applicantId = applicantId;
+    }
+
+    public void accept() {
+        this.status = ApplicationStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        this.status = ApplicationStatus.REJECTED;
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/application/entity/ApplicationStatus.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/entity/ApplicationStatus.java
@@ -1,0 +1,7 @@
+package com.techeer.carpool.domain.application.entity;
+
+public enum ApplicationStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/application/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/repository/ApplicationRepository.java
@@ -1,0 +1,19 @@
+package com.techeer.carpool.domain.application.repository;
+
+import com.techeer.carpool.domain.application.entity.Application;
+import com.techeer.carpool.domain.application.entity.ApplicationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+
+    boolean existsByPostIdAndApplicantId(Long postId, Long applicantId);
+
+    List<Application> findByApplicantIdOrderByCreatedAtDesc(Long applicantId);
+
+    List<Application> findByPostIdOrderByCreatedAtAsc(Long postId);
+
+    long countByPostIdAndStatus(Long postId, ApplicationStatus status);
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationCreateService.java
@@ -1,0 +1,54 @@
+package com.techeer.carpool.domain.application.service;
+
+import com.techeer.carpool.domain.application.dto.ApplicationResponse;
+import com.techeer.carpool.domain.application.entity.Application;
+import com.techeer.carpool.domain.application.repository.ApplicationRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationCreateService {
+
+    private final ApplicationRepository applicationRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public ApplicationResponse apply(Long postId, Long applicantId) {
+        Post post = postRepository.findByIdAndDeletedFalse(postId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        if (post.getMemberId().equals(applicantId)) {
+            throw new CarpoolException(ErrorCode.APPLICATION_SELF);
+        }
+
+        if (post.isFull()) {
+            throw new CarpoolException(ErrorCode.APPLICATION_POST_FULL);
+        }
+
+        if (applicationRepository.existsByPostIdAndApplicantId(postId, applicantId)) {
+            throw new CarpoolException(ErrorCode.APPLICATION_DUPLICATE);
+        }
+
+        Application application = Application.builder()
+                .postId(postId)
+                .applicantId(applicantId)
+                .build();
+
+        Application saved = applicationRepository.save(application);
+
+        String nickname = memberRepository.findById(applicantId)
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+
+        return ApplicationResponse.of(saved, nickname);
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationReadService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationReadService.java
@@ -1,0 +1,66 @@
+package com.techeer.carpool.domain.application.service;
+
+import com.techeer.carpool.domain.application.dto.ApplicationResponse;
+import com.techeer.carpool.domain.application.entity.Application;
+import com.techeer.carpool.domain.application.repository.ApplicationRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationReadService {
+
+    private final ApplicationRepository applicationRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public List<ApplicationResponse> getMyApplications(Long applicantId) {
+        List<Application> applications = applicationRepository
+                .findByApplicantIdOrderByCreatedAtDesc(applicantId);
+
+        String nickname = memberRepository.findById(applicantId)
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+
+        return applications.stream()
+                .map(a -> ApplicationResponse.of(a, nickname))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApplicationResponse> getApplicationsByPost(Long postId, Long requesterId) {
+        Post post = postRepository.findByIdAndDeletedFalse(postId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.APPLICATION_FORBIDDEN);
+        }
+
+        List<Application> applications = applicationRepository
+                .findByPostIdOrderByCreatedAtAsc(postId);
+
+        Set<Long> applicantIds = applications.stream()
+                .map(Application::getApplicantId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> nicknameMap = memberRepository.findAllById(applicantIds).stream()
+                .collect(Collectors.toMap(Member::getId, Member::getNickname));
+
+        return applications.stream()
+                .map(a -> ApplicationResponse.of(a, nicknameMap.getOrDefault(a.getApplicantId(), "알 수 없음")))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationStatusService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationStatusService.java
@@ -1,0 +1,78 @@
+package com.techeer.carpool.domain.application.service;
+
+import com.techeer.carpool.domain.application.dto.ApplicationResponse;
+import com.techeer.carpool.domain.application.entity.Application;
+import com.techeer.carpool.domain.application.entity.ApplicationStatus;
+import com.techeer.carpool.domain.application.repository.ApplicationRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationStatusService {
+
+    private final ApplicationRepository applicationRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public ApplicationResponse accept(Long applicationId, Long requesterId) {
+        Application application = findPending(applicationId);
+
+        Post post = postRepository.findByIdAndDeletedFalse(application.getPostId())
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.APPLICATION_FORBIDDEN);
+        }
+
+        if (post.isFull()) {
+            throw new CarpoolException(ErrorCode.APPLICATION_POST_FULL);
+        }
+
+        application.accept();
+        post.incrementPassengers();
+
+        return toResponse(application);
+    }
+
+    @Transactional
+    public ApplicationResponse reject(Long applicationId, Long requesterId) {
+        Application application = findPending(applicationId);
+
+        Post post = postRepository.findByIdAndDeletedFalse(application.getPostId())
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.APPLICATION_FORBIDDEN);
+        }
+
+        application.reject();
+        return toResponse(application);
+    }
+
+    private Application findPending(Long applicationId) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.APPLICATION_NOT_FOUND));
+
+        if (application.getStatus() != ApplicationStatus.PENDING) {
+            throw new CarpoolException(ErrorCode.APPLICATION_ALREADY_PROCESSED);
+        }
+
+        return application;
+    }
+
+    private ApplicationResponse toResponse(Application application) {
+        String nickname = memberRepository.findById(application.getApplicantId())
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return ApplicationResponse.of(application, nickname);
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/controller/CommentController.java
@@ -1,0 +1,49 @@
+package com.techeer.carpool.domain.comment.controller;
+
+import com.techeer.carpool.domain.comment.dto.CommentCreateRequest;
+import com.techeer.carpool.domain.comment.dto.CommentResponse;
+import com.techeer.carpool.domain.comment.service.CommentCreateService;
+import com.techeer.carpool.domain.comment.service.CommentDeleteService;
+import com.techeer.carpool.domain.comment.service.CommentReadService;
+import com.techeer.carpool.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentCreateService commentCreateService;
+    private final CommentReadService commentReadService;
+    private final CommentDeleteService commentDeleteService;
+
+    @PostMapping("/api/v1/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of("댓글이 작성되었습니다.", commentCreateService.createComment(postId, request, memberId)));
+    }
+
+    @GetMapping("/api/v1/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<List<CommentResponse>>> getComments(@PathVariable Long postId) {
+        return ResponseEntity.ok(ApiResponse.of("댓글 목록 조회 성공", commentReadService.getCommentsByPostId(postId)));
+    }
+
+    @DeleteMapping("/api/v1/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable Long commentId,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        commentDeleteService.deleteComment(commentId, memberId);
+        return ResponseEntity.ok(ApiResponse.of("댓글이 삭제되었습니다."));
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/dto/CommentCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,15 @@
+package com.techeer.carpool.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentCreateRequest {
+
+    @NotBlank(message = "댓글 내용을 입력해주세요.")
+    @Size(max = 500, message = "댓글은 500자 이내로 입력해주세요.")
+    private String content;
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/dto/CommentResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,30 @@
+package com.techeer.carpool.domain.comment.dto;
+
+import com.techeer.carpool.domain.comment.entity.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentResponse {
+
+    private Long id;
+    private Long postId;
+    private Long memberId;
+    private String nickname;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static CommentResponse from(Comment comment, String nickname) {
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .postId(comment.getPostId())
+                .memberId(comment.getMemberId())
+                .nickname(nickname)
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/entity/Comment.java
@@ -1,0 +1,53 @@
+package com.techeer.carpool.domain.comment.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long postId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private boolean deleted;
+
+    @PrePersist
+    private void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.deleted = false;
+    }
+
+    @Builder
+    public Comment(Long postId, Long memberId, String content) {
+        this.postId = postId;
+        this.memberId = memberId;
+        this.content = content;
+    }
+
+    public void delete() {
+        this.deleted = true;
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.techeer.carpool.domain.comment.repository;
+
+import com.techeer.carpool.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByPostIdAndDeletedFalseOrderByCreatedAtAsc(Long postId);
+
+    Optional<Comment> findByIdAndDeletedFalse(Long id);
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentCreateService.java
@@ -1,0 +1,41 @@
+package com.techeer.carpool.domain.comment.service;
+
+import com.techeer.carpool.domain.comment.dto.CommentCreateRequest;
+import com.techeer.carpool.domain.comment.dto.CommentResponse;
+import com.techeer.carpool.domain.comment.entity.Comment;
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCreateService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public CommentResponse createComment(Long postId, CommentCreateRequest request, Long memberId) {
+        postRepository.findByIdAndDeletedFalse(postId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        Comment comment = Comment.builder()
+                .postId(postId)
+                .memberId(memberId)
+                .content(request.getContent())
+                .build();
+
+        Comment saved = commentRepository.save(comment);
+        String nickname = memberRepository.findById(memberId)
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return CommentResponse.from(saved, nickname);
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentDeleteService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentDeleteService.java
@@ -1,0 +1,27 @@
+package com.techeer.carpool.domain.comment.service;
+
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentDeleteService {
+
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void deleteComment(Long commentId, Long memberId) {
+        var comment = commentRepository.findByIdAndDeletedFalse(commentId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getMemberId().equals(memberId)) {
+            throw new CarpoolException(ErrorCode.COMMENT_FORBIDDEN);
+        }
+
+        comment.delete();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentReadService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/comment/service/CommentReadService.java
@@ -1,0 +1,46 @@
+package com.techeer.carpool.domain.comment.service;
+
+import com.techeer.carpool.domain.comment.dto.CommentResponse;
+import com.techeer.carpool.domain.comment.entity.Comment;
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReadService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentsByPostId(Long postId) {
+        postRepository.findByIdAndDeletedFalse(postId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        List<Comment> comments = commentRepository.findByPostIdAndDeletedFalseOrderByCreatedAtAsc(postId);
+
+        Set<Long> memberIds = comments.stream()
+                .map(Comment::getMemberId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, Member::getNickname));
+
+        return comments.stream()
+                .map(c -> CommentResponse.from(c, nicknameMap.getOrDefault(c.getMemberId(), "알 수 없음")))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
@@ -11,6 +11,7 @@ import com.techeer.carpool.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,9 +27,12 @@ public class PostController {
     private final PostDeleteService postDeleteService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<PostResponse>> createPost(@RequestBody PostCreateRequest request) {
+    public ResponseEntity<ApiResponse<PostResponse>> createPost(
+            @RequestBody PostCreateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.of("게시글이 생성되었습니다.", postCreateService.createPost(request)));
+                .body(ApiResponse.of("게시글이 생성되었습니다.", postCreateService.createPost(request, memberId)));
     }
 
     @GetMapping
@@ -42,14 +46,20 @@ public class PostController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<PostResponse>> updatePost(@PathVariable Long id,
-                                                                @RequestBody PostUpdateRequest request) {
-        return ResponseEntity.ok(ApiResponse.of("게시글이 수정되었습니다.", postUpdateService.updatePost(id, request)));
+    public ResponseEntity<ApiResponse<PostResponse>> updatePost(
+            @PathVariable Long id,
+            @RequestBody PostUpdateRequest request,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("게시글이 수정되었습니다.", postUpdateService.updatePost(id, request, memberId)));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
-        postDeleteService.deletePost(id);
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        postDeleteService.deletePost(id, memberId);
         return ResponseEntity.ok(ApiResponse.of("게시글이 삭제되었습니다."));
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Builder
 public class PostCreateRequest {
 
-    private Long memberId;
     private String title;
     private String departureLocation;
     private Double departureLat;

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
@@ -14,7 +14,6 @@ import java.util.List;
 @Builder
 public class PostCreateRequest {
 
-    private Long memberId;
     private String title;
     private String departureLocation;
     private Double departureLat;

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -25,4 +26,6 @@ public class PostCreateRequest {
     private int maxPassengers;
     private String description;
     private boolean autoAccept;
+    private Integer price;
+    private List<String> tags;
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -13,6 +14,7 @@ public class PostResponse {
 
     private Long id;
     private Long memberId;
+    private String nickname;
     private String title;
     private String departureLocation;
     private Double departureLat;
@@ -26,13 +28,16 @@ public class PostResponse {
     private PostStatus status;
     private String description;
     private boolean autoAccept;
+    private Integer price;
+    private List<String> tags;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static PostResponse from(Post post) {
+    public static PostResponse from(Post post, String nickname) {
         return PostResponse.builder()
                 .id(post.getId())
                 .memberId(post.getMemberId())
+                .nickname(nickname)
                 .title(post.getTitle())
                 .departureLocation(post.getDepartureLocation())
                 .departureLat(post.getDepartureLat())
@@ -46,6 +51,8 @@ public class PostResponse {
                 .status(post.getStatus())
                 .description(post.getDescription())
                 .autoAccept(post.isAutoAccept())
+                .price(post.getPrice())
+                .tags(post.getTags())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostUpdateRequest.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -26,4 +27,6 @@ public class PostUpdateRequest {
     private String description;
     private boolean autoAccept;
     private PostStatus status;
+    private Integer price;
+    private List<String> tags;
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -59,6 +61,13 @@ public class Post {
     @Column(nullable = false)
     private boolean autoAccept;
 
+    private Integer price;
+
+    @ElementCollection
+    @CollectionTable(name = "post_tags", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "tag")
+    private List<String> tags = new ArrayList<>();
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -87,7 +96,8 @@ public class Post {
                 String departureLocation, Double departureLat, Double departureLng,
                 String destinationLocation, Double destinationLat, Double destinationLng,
                 LocalDateTime departureTime, int maxPassengers,
-                String description, boolean autoAccept) {
+                String description, boolean autoAccept,
+                Integer price, List<String> tags) {
         this.memberId = memberId;
         this.title = title;
         this.departureLocation = departureLocation;
@@ -100,6 +110,8 @@ public class Post {
         this.maxPassengers = maxPassengers;
         this.description = description;
         this.autoAccept = autoAccept;
+        this.price = price;
+        this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
     }
 
     public void updateFrom(PostUpdateRequest request) {
@@ -115,6 +127,8 @@ public class Post {
         this.description = request.getDescription();
         this.autoAccept = request.isAutoAccept();
         this.status = request.getStatus();
+        this.price = request.getPrice();
+        this.tags = request.getTags() != null ? new ArrayList<>(request.getTags()) : new ArrayList<>();
     }
 
     public void delete() {

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -98,6 +98,17 @@ public class Post extends SoftDeletableEntity {
         this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
     }
 
+    public boolean isFull() {
+        return this.currentPassengers >= this.maxPassengers;
+    }
+
+    public void incrementPassengers() {
+        this.currentPassengers++;
+        if (this.currentPassengers >= this.maxPassengers) {
+            this.status = PostStatus.CLOSED;
+        }
+    }
+
     public void updateFrom(PostUpdateRequest request) {
         this.title = request.getTitle();
         this.departureLocation = request.getDepartureLocation();

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
@@ -1,5 +1,7 @@
 package com.techeer.carpool.domain.post.service;
 
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.dto.PostCreateRequest;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.entity.Post;
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostCreateService {
 
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public PostResponse createPost(PostCreateRequest request) {
@@ -29,8 +32,13 @@ public class PostCreateService {
                 .maxPassengers(request.getMaxPassengers())
                 .description(request.getDescription())
                 .autoAccept(request.isAutoAccept())
+                .price(request.getPrice())
+                .tags(request.getTags())
                 .build();
-
-        return PostResponse.from(postRepository.save(post));
+        Post saved = postRepository.save(post);
+        String nickname = memberRepository.findById(saved.getMemberId())
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return PostResponse.from(saved, nickname);
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
@@ -18,9 +18,9 @@ public class PostCreateService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public PostResponse createPost(PostCreateRequest request) {
+    public PostResponse createPost(PostCreateRequest request, Long memberId) {
         Post post = Post.builder()
-                .memberId(request.getMemberId())
+                .memberId(memberId)
                 .title(request.getTitle())
                 .departureLocation(request.getDepartureLocation())
                 .departureLat(request.getDepartureLat())

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
@@ -15,9 +15,9 @@ public class PostCreateService {
     private final PostRepository postRepository;
 
     @Transactional
-    public PostResponse createPost(PostCreateRequest request) {
+    public PostResponse createPost(PostCreateRequest request, Long memberId) {
         Post post = Post.builder()
-                .memberId(request.getMemberId())
+                .memberId(memberId)
                 .title(request.getTitle())
                 .departureLocation(request.getDepartureLocation())
                 .departureLat(request.getDepartureLat())

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostDeleteService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostDeleteService.java
@@ -15,9 +15,12 @@ public class PostDeleteService {
     private final PostRepository postRepository;
 
     @Transactional
-    public void deletePost(Long id) {
+    public void deletePost(Long id, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
+        }
         post.delete();
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostReadService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostReadService.java
@@ -1,5 +1,7 @@
 package com.techeer.carpool.domain.post.service;
 
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.repository.PostRepository;
@@ -10,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -18,17 +22,24 @@ import java.util.stream.Collectors;
 public class PostReadService {
 
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
     public List<PostResponse> getAllPosts() {
-        return postRepository.findByDeletedFalseOrderByCreatedAtDesc()
-                .stream()
-                .map(PostResponse::from)
+        List<Post> posts = postRepository.findByDeletedFalseOrderByCreatedAtDesc();
+        Set<Long> memberIds = posts.stream().map(Post::getMemberId).collect(Collectors.toSet());
+        Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, Member::getNickname));
+        return posts.stream()
+                .map(p -> PostResponse.from(p, nicknameMap.getOrDefault(p.getMemberId(), "알 수 없음")))
                 .collect(Collectors.toList());
     }
 
     public PostResponse getPostById(Long id) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
-        return PostResponse.from(post);
+        String nickname = memberRepository.findById(post.getMemberId())
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return PostResponse.from(post, nickname);
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
@@ -20,9 +20,12 @@ public class PostUpdateService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public PostResponse updatePost(Long id, PostUpdateRequest request) {
+    public PostResponse updatePost(Long id, PostUpdateRequest request, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
+        }
         post.updateFrom(request);
         String nickname = memberRepository.findById(post.getMemberId())
                 .map(Member::getNickname)

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
@@ -17,9 +17,12 @@ public class PostUpdateService {
     private final PostRepository postRepository;
 
     @Transactional
-    public PostResponse updatePost(Long id, PostUpdateRequest request) {
+    public PostResponse updatePost(Long id, PostUpdateRequest request, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
+        }
         post.updateFrom(request);
         return PostResponse.from(post);
     }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
@@ -1,5 +1,7 @@
 package com.techeer.carpool.domain.post.service;
 
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.dto.PostUpdateRequest;
 import com.techeer.carpool.domain.post.entity.Post;
@@ -15,12 +17,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostUpdateService {
 
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public PostResponse updatePost(Long id, PostUpdateRequest request) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
         post.updateFrom(request);
-        return PostResponse.from(post);
+        String nickname = memberRepository.findById(post.getMemberId())
+                .map(Member::getNickname)
+                .orElse("알 수 없음");
+        return PostResponse.from(post, nickname);
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
@@ -5,11 +5,17 @@ import com.techeer.carpool.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -21,15 +27,29 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts", "/api/v1/posts/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     POST_NOT_FOUND("POST_001", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_NOT_FOUND("COMMENT_001", "댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_FORBIDDEN("COMMENT_002", "댓글 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     POST_NOT_FOUND("POST_001", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    POST_FORBIDDEN("POST_002", "게시글 수정/삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -8,6 +8,12 @@ public enum ErrorCode {
     POST_FORBIDDEN("POST_002", "게시글 수정/삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     COMMENT_NOT_FOUND("COMMENT_001", "댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     COMMENT_FORBIDDEN("COMMENT_002", "댓글 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    APPLICATION_NOT_FOUND("APPLICATION_001", "신청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    APPLICATION_DUPLICATE("APPLICATION_002", "이미 신청한 게시글입니다.", HttpStatus.CONFLICT),
+    APPLICATION_SELF("APPLICATION_003", "본인 게시글에는 신청할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    APPLICATION_FORBIDDEN("APPLICATION_004", "신청 수락/거절 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    APPLICATION_POST_FULL("APPLICATION_005", "정원이 가득 찬 게시글입니다.", HttpStatus.CONFLICT),
+    APPLICATION_ALREADY_PROCESSED("APPLICATION_006", "이미 처리된 신청입니다.", HttpStatus.CONFLICT),
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -51,6 +51,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .maxPassengers(3)
                 .description("정시 출발합니다. 짐 많으신 분은 미리 말씀해 주세요.")
                 .autoAccept(false)
+                .price(5000)
                 .build());
 
         Post p2 = postRepository.save(Post.builder()
@@ -64,6 +65,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .maxPassengers(2)
                 .description("경유지 없이 직행입니다.")
                 .autoAccept(true)
+                .price(3000)
                 .build());
 
         Post p3 = postRepository.save(Post.builder()
@@ -77,6 +79,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .maxPassengers(4)
                 .description("반드시 제시간에 탑승 부탁드립니다.")
                 .autoAccept(false)
+                .price(4000)
                 .build());
 
         seedComments(p1, test, admin);

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -1,13 +1,20 @@
 package com.techeer.carpool.global.init;
 
+import com.techeer.carpool.domain.comment.entity.Comment;
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
 import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Profile("local")
@@ -16,22 +23,91 @@ import org.springframework.stereotype.Component;
 public class LocalDataInitializer implements CommandLineRunner {
 
     private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
     public void run(String... args) {
-        createIfNotExists("test@carpool.com", "password1234", "테스트유저");
-        createIfNotExists("admin@carpool.com", "admin1234!", "관리자");
-        log.info("[LocalDataInitializer] 테스트 계정 생성 완료");
+        Member test  = createMemberIfNotExists("test@carpool.com",  "password1234", "테스트유저");
+        Member admin = createMemberIfNotExists("admin@carpool.com", "admin1234!",   "관리자");
+
+        if (postRepository.findByDeletedFalseOrderByCreatedAtDesc().isEmpty()) {
+            seedPosts(test, admin);
+        }
+
+        log.info("[LocalDataInitializer] 초기 데이터 생성 완료");
     }
 
-    private void createIfNotExists(String email, String password, String nickname) {
-        if (!memberRepository.existsByEmail(email)) {
-            memberRepository.save(Member.builder()
-                    .email(email)
-                    .password(passwordEncoder.encode(password))
-                    .nickname(nickname)
-                    .build());
-        }
+    private void seedPosts(Member test, Member admin) {
+        Post p1 = postRepository.save(Post.builder()
+                .memberId(admin.getId())
+                .title("강남역 → 판교역")
+                .departureLocation("강남역")
+                .departureLat(37.4979).departureLng(127.0276)
+                .destinationLocation("판교역")
+                .destinationLat(37.3943).destinationLng(127.1110)
+                .departureTime(LocalDateTime.now().plusDays(1).withHour(8).withMinute(30).withSecond(0).withNano(0))
+                .maxPassengers(3)
+                .description("정시 출발합니다. 짐 많으신 분은 미리 말씀해 주세요.")
+                .autoAccept(false)
+                .build());
+
+        Post p2 = postRepository.save(Post.builder()
+                .memberId(test.getId())
+                .title("홍대입구 → 여의도역")
+                .departureLocation("홍대입구")
+                .departureLat(37.5572).departureLng(126.9247)
+                .destinationLocation("여의도역")
+                .destinationLat(37.5215).destinationLng(126.9242)
+                .departureTime(LocalDateTime.now().plusDays(2).withHour(9).withMinute(0).withSecond(0).withNano(0))
+                .maxPassengers(2)
+                .description("경유지 없이 직행입니다.")
+                .autoAccept(true)
+                .build());
+
+        Post p3 = postRepository.save(Post.builder()
+                .memberId(admin.getId())
+                .title("서울역 → 수원역")
+                .departureLocation("서울역")
+                .departureLat(37.5547).departureLng(126.9707)
+                .destinationLocation("수원역")
+                .destinationLat(37.2664).destinationLng(127.0003)
+                .departureTime(LocalDateTime.now().plusDays(3).withHour(7).withMinute(0).withSecond(0).withNano(0))
+                .maxPassengers(4)
+                .description("반드시 제시간에 탑승 부탁드립니다.")
+                .autoAccept(false)
+                .build());
+
+        seedComments(p1, test, admin);
+        seedComments(p2, admin, test);
+        seedComments(p3, test, admin);
+    }
+
+    private void seedComments(Post post, Member first, Member second) {
+        commentRepository.save(Comment.builder()
+                .postId(post.getId())
+                .memberId(first.getId())
+                .content("저도 같은 방향이에요! 탑승 가능할까요?")
+                .build());
+        commentRepository.save(Comment.builder()
+                .postId(post.getId())
+                .memberId(second.getId())
+                .content("몇 시쯤 도착 예정인가요?")
+                .build());
+        commentRepository.save(Comment.builder()
+                .postId(post.getId())
+                .memberId(first.getId())
+                .content("좋아요, 당일 아침에 다시 연락 드릴게요 :)")
+                .build());
+    }
+
+    private Member createMemberIfNotExists(String email, String password, String nickname) {
+        return memberRepository.findByEmail(email).orElseGet(() ->
+                memberRepository.save(Member.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode(password))
+                        .nickname(nickname)
+                        .build()));
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/global/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/techeer/carpool/global/jwt/JwtTokenProvider.java
@@ -45,7 +45,11 @@ public class JwtTokenProvider {
     }
 
     public Long getMemberIdFromToken(String token) {
-        return getClaims(token).get("memberId", Long.class);
+        Object value = getClaims(token).get("memberId");
+        if (value instanceof Long) return (Long) value;
+        if (value instanceof Integer) return ((Integer) value).longValue();
+        if (value instanceof Number) return ((Number) value).longValue();
+        return null;
     }
 
     public LocalDateTime getRefreshTokenExpiresAt() {

--- a/backend/src/test/java/com/techeer/carpool/domain/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/comment/CommentIntegrationTest.java
@@ -1,0 +1,168 @@
+package com.techeer.carpool.domain.comment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.carpool.domain.comment.dto.CommentCreateRequest;
+import com.techeer.carpool.domain.comment.entity.Comment;
+import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CommentIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired CommentRepository commentRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+
+    private Long memberId;
+    private Long otherMemberId;
+    private Long postId;
+    private String token;
+    private String otherToken;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository.deleteAll();
+        postRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        Member member = memberRepository.save(Member.builder()
+                .email("test@test.com")
+                .password("password")
+                .nickname("테스터")
+                .build());
+        memberId = member.getId();
+        token = "Bearer " + jwtTokenProvider.createAccessToken(memberId);
+
+        Member other = memberRepository.save(Member.builder()
+                .email("other@test.com")
+                .password("password")
+                .nickname("다른유저")
+                .build());
+        otherMemberId = other.getId();
+        otherToken = "Bearer " + jwtTokenProvider.createAccessToken(otherMemberId);
+
+        Post post = postRepository.save(Post.builder()
+                .memberId(memberId)
+                .title("테스트 카풀")
+                .departureLocation("강남역")
+                .destinationLocation("판교역")
+                .departureTime(LocalDateTime.now().plusDays(1))
+                .maxPassengers(3)
+                .description("테스트")
+                .autoAccept(false)
+                .build());
+        postId = post.getId();
+    }
+
+    @Test
+    @DisplayName("댓글 작성 성공")
+    void createComment_success() throws Exception {
+        CommentCreateRequest request = new CommentCreateRequest();
+        setField(request, "content", "탑승 신청합니다!");
+
+        mockMvc.perform(post("/api/v1/posts/{postId}/comments", postId)
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.content").value("탑승 신청합니다!"))
+                .andExpect(jsonPath("$.data.nickname").value("테스터"))
+                .andExpect(jsonPath("$.data.postId").value(postId));
+    }
+
+    @Test
+    @DisplayName("댓글 목록 조회 성공")
+    void getComments_success() throws Exception {
+        commentRepository.save(Comment.builder()
+                .postId(postId).memberId(memberId).content("첫 번째 댓글").build());
+        commentRepository.save(Comment.builder()
+                .postId(postId).memberId(memberId).content("두 번째 댓글").build());
+
+        mockMvc.perform(get("/api/v1/posts/{postId}/comments", postId)
+                        .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].content").value("첫 번째 댓글"))
+                .andExpect(jsonPath("$.data[1].content").value("두 번째 댓글"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글에 댓글 작성 시 404")
+    void createComment_postNotFound() throws Exception {
+        CommentCreateRequest request = new CommentCreateRequest();
+        setField(request, "content", "댓글");
+
+        mockMvc.perform(post("/api/v1/posts/{postId}/comments", 999L)
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_001"));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공 - 본인")
+    void deleteComment_success() throws Exception {
+        Comment comment = commentRepository.save(Comment.builder()
+                .postId(postId).memberId(memberId).content("삭제될 댓글").build());
+
+        mockMvc.perform(delete("/api/v1/comments/{commentId}", comment.getId())
+                        .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("댓글이 삭제되었습니다."));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 실패 - 타인")
+    void deleteComment_forbidden() throws Exception {
+        Comment comment = commentRepository.save(Comment.builder()
+                .postId(postId).memberId(memberId).content("남의 댓글").build());
+
+        mockMvc.perform(delete("/api/v1/comments/{commentId}", comment.getId())
+                        .header("Authorization", otherToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMENT_002"));
+    }
+
+    @Test
+    @DisplayName("빈 내용으로 댓글 작성 시 400")
+    void createComment_emptyContent() throws Exception {
+        CommentCreateRequest request = new CommentCreateRequest();
+        setField(request, "content", "");
+
+        mockMvc.perform(post("/api/v1/posts/{postId}/comments", postId)
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    private void setField(Object obj, String fieldName, Object value) throws Exception {
+        var field = obj.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+}

--- a/backend/src/test/java/com/techeer/carpool/domain/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/comment/CommentIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.techeer.carpool.domain.comment;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.techeer.carpool.domain.comment.dto.CommentCreateRequest;
 import com.techeer.carpool.domain.comment.entity.Comment;
 import com.techeer.carpool.domain.comment.repository.CommentRepository;
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;


### PR DESCRIPTION
## Summary
Closes #33

카풀 신청/조회/수락/거절 흐름을 담당하는 Application 도메인을 신규 구현했습니다.

## 구현된 API

| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/v1/posts/{postId}/applications` | 카풀 신청 |
| GET | `/api/v1/applications/me` | 내가 신청한 내역 조회 |
| GET | `/api/v1/posts/{postId}/applications` | 내 게시글에 들어온 신청 조회 (작성자 전용) |
| PATCH | `/api/v1/applications/{id}/accept` | 신청 수락 |
| PATCH | `/api/v1/applications/{id}/reject` | 신청 거절 |

## 비즈니스 규칙
- 본인 게시글 신청 불가 (`APPLICATION_003`)
- 동일 게시글 중복 신청 불가 (`APPLICATION_002`, DB unique constraint)
- 정원 초과 시 신청 불가 (`APPLICATION_005`)
- 수락/거절은 게시글 작성자만 가능 (`APPLICATION_004`)
- 이미 처리된 신청 재처리 불가 (`APPLICATION_006`)
- 수락 시 `Post.currentPassengers` 증가, 정원 도달 시 상태 `CLOSED` 자동 전환

## 추가 수정
- `Post.isFull()`, `Post.incrementPassengers()` 메서드 추가
- `SecurityConfig`: CORS 설정 복원 + Spring Security 7.x `requestMatchers` String → `HttpMethod` 타입 수정 (기존 버그)

## 커밋 구조
- `entity`: Application, ApplicationStatus, ErrorCode 에러코드
- `dto`: ApplicationResponse
- `repository`: ApplicationRepository
- `service`: ApplicationCreateService, ApplicationReadService, ApplicationStatusService
- `controller`: ApplicationController

## Test plan
- [ ] 로그인 후 타인 게시글 신청 → 201 Created
- [ ] 본인 게시글 신청 → 400 (APPLICATION_003)
- [ ] 동일 게시글 재신청 → 409 (APPLICATION_002)
- [ ] `GET /api/v1/applications/me` → 내 신청 목록 반환
- [ ] 게시글 작성자로 `GET /api/v1/posts/{id}/applications` → 신청 목록 반환
- [ ] 타인으로 위 조회 → 403 (APPLICATION_004)
- [ ] 수락 → 200, `Post.currentPassengers` 증가 확인
- [ ] 거절 → 200, 상태 REJECTED
- [ ] 이미 수락된 신청 재수락 → 409 (APPLICATION_006)