### PR TITLE
fix: backend security & validation improvements

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
@@ -18,15 +18,18 @@ public class MemberController {
     private final MemberProfileService memberProfileService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<ProfileResponse>> getProfileById(@PathVariable Long id) {
-        ProfileResponse profile = memberProfileService.getProfile(id);
+    public ResponseEntity<ApiResponse<ProfileResponse>> getProfileById(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getPrincipal();
+        ProfileResponse profile = memberProfileService.getProfile(requesterId, id);
         return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
     }
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<ProfileResponse>> getProfile(Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
-        ProfileResponse profile = memberProfileService.getProfile(memberId);
+        ProfileResponse profile = memberProfileService.getProfile(memberId, memberId);
         return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
     }
 

--- a/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberProfileService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberProfileService.java
@@ -18,7 +18,10 @@ public class MemberProfileService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public ProfileResponse getProfile(Long memberId) {
+    public ProfileResponse getProfile(Long requesterId, Long memberId) {
+        if (!requesterId.equals(memberId)) {
+            throw new CarpoolException(ErrorCode.MEMBER_FORBIDDEN);
+        }
         Member member = memberRepository.findByIdAndDeletedFalse(memberId)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.MEMBER_NOT_FOUND));
         return ProfileResponse.from(member);

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -1,5 +1,8 @@
 package com.techeer.carpool.domain.ride.service;
 
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.entity.PostStatus;
+import com.techeer.carpool.domain.post.repository.PostRepository;
 import com.techeer.carpool.domain.ride.dto.RideDto;
 import com.techeer.carpool.domain.ride.entity.Ride;
 import com.techeer.carpool.domain.ride.entity.RidePassenger;
@@ -24,16 +27,23 @@ public class RideService {
 
     private final RideRepository rideRepository;
     private final RidePassengerRepository ridePassengerRepository;
+    private final PostRepository postRepository;
 
     // 운행 생성
-    @Transactional  // 데이터 변경(INSERT)이 있으므로 readOnly=false인 트랜잭션으로 덮어씀
+    @Transactional
     public RideDto.RideResponse createRide(RideDto.CreateRequest request) {
-        // 요청 데이터로 Ride 엔티티 생성
+        Post post = postRepository.findByIdAndDeletedFalse(request.getPostId())
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+        if (!post.getMemberId().equals(request.getDriverId())) {
+            throw new CarpoolException(ErrorCode.RIDE_FORBIDDEN);
+        }
+        if (post.getStatus() != PostStatus.OPEN) {
+            throw new CarpoolException(ErrorCode.RIDE_INVALID_STATUS);
+        }
         Ride ride = Ride.builder()
                 .postId(request.getPostId())
                 .driverId(request.getDriverId())
                 .build();
-        // DB에 저장 후, 저장된 엔티티를 Response DTO로 변환해서 반환
         return RideDto.RideResponse.from(rideRepository.save(ride));
     }
 

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -5,7 +5,8 @@ import com.techeer.carpool.domain.ride.entity.Ride;
 import com.techeer.carpool.domain.ride.entity.RidePassenger;
 import com.techeer.carpool.domain.ride.repository.RidePassengerRepository;
 import com.techeer.carpool.domain.ride.repository.RideRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -101,14 +102,11 @@ public class RideService {
     // rideId로 Ride 조회, 없으면 404 예외 발생
     private Ride findRideById(Long rideId) {
         return rideRepository.findById(rideId)
-                .orElseThrow(() -> new EntityNotFoundException("운행을 찾을 수 없습니다. id=" + rideId));
-        // Optional.orElseThrow(): 값이 있으면 반환, 없으면 예외 던짐
+                .orElseThrow(() -> new CarpoolException(ErrorCode.RIDE_NOT_FOUND));
     }
 
-    // rideId + applicationId로 RidePassenger 조회, 없으면 404 예외 발생
     private RidePassenger findPassenger(Long rideId, Long applicationId) {
         return ridePassengerRepository.findByRideIdAndApplicationId(rideId, applicationId)
-                .orElseThrow(() -> new EntityNotFoundException(
-                        "탑승자를 찾을 수 없습니다. rideId=" + rideId + ", applicationId=" + applicationId));
+                .orElseThrow(() -> new CarpoolException(ErrorCode.RIDE_PASSENGER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -6,6 +6,7 @@ import com.techeer.carpool.domain.post.repository.PostRepository;
 import com.techeer.carpool.domain.ride.dto.RideDto;
 import com.techeer.carpool.domain.ride.entity.Ride;
 import com.techeer.carpool.domain.ride.entity.RidePassenger;
+import com.techeer.carpool.domain.ride.entity.RideStatus;
 import com.techeer.carpool.domain.ride.repository.RidePassengerRepository;
 import com.techeer.carpool.domain.ride.repository.RideRepository;
 import com.techeer.carpool.global.exception.CarpoolException;
@@ -93,16 +94,24 @@ public class RideService {
     // 탑승 확인 (드라이버가 특정 탑승자의 탑승을 확인)
     @Transactional
     public RideDto.PassengerResponse boardPassenger(Long rideId, Long applicationId) {
+        Ride ride = findRideById(rideId);
+        if (ride.getStatus() != RideStatus.IN_PROGRESS) {
+            throw new CarpoolException(ErrorCode.RIDE_INVALID_STATUS);
+        }
         RidePassenger passenger = findPassenger(rideId, applicationId);
-        passenger.board();  // 상태를 BOARDED로 변경
+        passenger.board();
         return RideDto.PassengerResponse.from(passenger);
     }
 
     // 하차 확인 (드라이버가 특정 탑승자의 하차를 확인)
     @Transactional
     public RideDto.PassengerResponse dropOffPassenger(Long rideId, Long applicationId) {
+        Ride ride = findRideById(rideId);
+        if (ride.getStatus() != RideStatus.IN_PROGRESS) {
+            throw new CarpoolException(ErrorCode.RIDE_INVALID_STATUS);
+        }
         RidePassenger passenger = findPassenger(rideId, applicationId);
-        passenger.dropOff();  // 상태를 DROPPED_OFF로 변경
+        passenger.dropOff();
         return RideDto.PassengerResponse.from(passenger);
     }
 

--- a/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.techeer.carpool.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -32,7 +31,6 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/posts", "/api/v1/posts/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.techeer.carpool.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -32,6 +33,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized"))
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -20,7 +20,12 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND("AUTH_002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_CREDENTIALS("AUTH_003", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_TOKEN("AUTH_004", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
-    EXPIRED_TOKEN("AUTH_005", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED);
+    EXPIRED_TOKEN("AUTH_005", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+
+    RIDE_NOT_FOUND("RIDE_001", "운행을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    RIDE_FORBIDDEN("RIDE_002", "운행 제어 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    RIDE_INVALID_STATUS("RIDE_003", "현재 상태에서 허용되지 않는 작업입니다.", HttpStatus.CONFLICT),
+    RIDE_PASSENGER_NOT_FOUND("RIDE_004", "탑승자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -25,7 +25,9 @@ public enum ErrorCode {
     RIDE_NOT_FOUND("RIDE_001", "운행을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     RIDE_FORBIDDEN("RIDE_002", "운행 제어 권한이 없습니다.", HttpStatus.FORBIDDEN),
     RIDE_INVALID_STATUS("RIDE_003", "현재 상태에서 허용되지 않는 작업입니다.", HttpStatus.CONFLICT),
-    RIDE_PASSENGER_NOT_FOUND("RIDE_004", "탑승자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    RIDE_PASSENGER_NOT_FOUND("RIDE_004", "탑승자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    MEMBER_FORBIDDEN("MEMBER_001", "본인의 프로필만 조회할 수 있습니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/backend/src/test/java/com/techeer/carpool/domain/application/ApplicationIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/application/ApplicationIntegrationTest.java
@@ -1,0 +1,283 @@
+package com.techeer.carpool.domain.application;
+
+import tools.jackson.databind.ObjectMapper;
+import com.techeer.carpool.domain.application.repository.ApplicationRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+
+import com.jayway.jsonpath.JsonPath;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ApplicationIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired ApplicationRepository applicationRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+
+    private Long ownerId;
+    private Long applicant1Id;
+    private Long applicant2Id;
+    private Long postId;
+    private String ownerToken;
+    private String applicant1Token;
+    private String applicant2Token;
+
+    @BeforeEach
+    void setUp() {
+        applicationRepository.deleteAll();
+        postRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        Member owner = memberRepository.save(Member.builder()
+                .email("owner@test.com").password("pw").nickname("작성자").build());
+        ownerId = owner.getId();
+        ownerToken = "Bearer " + jwtTokenProvider.createAccessToken(ownerId);
+
+        Member app1 = memberRepository.save(Member.builder()
+                .email("app1@test.com").password("pw").nickname("신청자1").build());
+        applicant1Id = app1.getId();
+        applicant1Token = "Bearer " + jwtTokenProvider.createAccessToken(applicant1Id);
+
+        Member app2 = memberRepository.save(Member.builder()
+                .email("app2@test.com").password("pw").nickname("신청자2").build());
+        applicant2Id = app2.getId();
+        applicant2Token = "Bearer " + jwtTokenProvider.createAccessToken(applicant2Id);
+
+        Post post = postRepository.save(Post.builder()
+                .memberId(ownerId)
+                .title("카풀 모집")
+                .departureLocation("강남역").departureLat(37.4979).departureLng(127.0276)
+                .destinationLocation("판교역").destinationLat(37.3943).destinationLng(127.1110)
+                .departureTime(LocalDateTime.now().plusDays(1))
+                .maxPassengers(3)
+                .description("테스트")
+                .autoAccept(false)
+                .build());
+        postId = post.getId();
+    }
+
+    // ── 신청 ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("카풀 신청 성공")
+    void apply_success() throws Exception {
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.postId").value(postId))
+                .andExpect(jsonPath("$.data.status").value("PENDING"))
+                .andExpect(jsonPath("$.data.applicantNickname").value("신청자1"));
+    }
+
+    @Test
+    @DisplayName("카풀 신청 실패 - 본인 게시글 신청")
+    void apply_ownPost() throws Exception {
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("APPLICATION_003"));
+    }
+
+    @Test
+    @DisplayName("카풀 신청 실패 - 중복 신청")
+    void apply_duplicate() throws Exception {
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("APPLICATION_002"));
+    }
+
+    @Test
+    @DisplayName("카풀 신청 실패 - 정원 초과")
+    void apply_postFull() throws Exception {
+        // maxPassengers=1 인 게시글 생성
+        Post smallPost = postRepository.save(Post.builder()
+                .memberId(ownerId)
+                .title("1인 카풀")
+                .departureLocation("강남역").departureLat(37.4979).departureLng(127.0276)
+                .destinationLocation("판교역").destinationLat(37.3943).destinationLng(127.1110)
+                .departureTime(LocalDateTime.now().plusDays(1))
+                .maxPassengers(1)
+                .autoAccept(false)
+                .build());
+        Long smallPostId = smallPost.getId();
+
+        // 신청자1 신청
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", smallPostId)
+                        .header("Authorization", applicant1Token))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        // 작성자가 수락 → currentPassengers=1, 정원 마감
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk());
+
+        // 신청자2가 신청 시도 → 정원 초과
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", smallPostId)
+                        .header("Authorization", applicant2Token))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("APPLICATION_005"));
+    }
+
+    @Test
+    @DisplayName("카풀 신청 실패 - 존재하지 않는 게시글")
+    void apply_postNotFound() throws Exception {
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", 99999L)
+                        .header("Authorization", applicant1Token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_001"));
+    }
+
+    // ── 신청 목록 조회 ───────────────────────────────────────
+
+    @Test
+    @DisplayName("내 신청 내역 조회 성공")
+    void getMyApplications_success() throws Exception {
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token));
+
+        mockMvc.perform(get("/api/v1/applications/me")
+                        .header("Authorization", applicant1Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].postId").value(postId));
+    }
+
+    @Test
+    @DisplayName("게시글 신청 목록 조회 성공 - 작성자")
+    void getPostApplications_owner() throws Exception {
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token));
+        mockMvc.perform(post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant2Token));
+
+        mockMvc.perform(get("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("게시글 신청 목록 조회 실패 - 비작성자 접근")
+    void getPostApplications_notOwner() throws Exception {
+        mockMvc.perform(get("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("APPLICATION_004"));
+    }
+
+    // ── 신청 수락/거절 ───────────────────────────────────────
+
+    @Test
+    @DisplayName("신청 수락 성공 - 상태 ACCEPTED, currentPassengers 증가")
+    void accept_success() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("ACCEPTED"));
+
+        // 게시글 currentPassengers 1 증가 확인
+        mockMvc.perform(get("/api/v1/posts/{id}", postId)
+                        .header("Authorization", ownerToken))
+                .andExpect(jsonPath("$.data.currentPassengers").value(1));
+    }
+
+    @Test
+    @DisplayName("신청 거절 성공 - 상태 REJECTED")
+    void reject_success() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/reject", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("REJECTED"));
+    }
+
+    @Test
+    @DisplayName("신청 수락 실패 - 이미 처리된 신청")
+    void accept_alreadyProcessed() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", applicationId)
+                        .header("Authorization", ownerToken));
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("APPLICATION_006"));
+    }
+
+    @Test
+    @DisplayName("신청 수락 실패 - 권한 없음 (비작성자)")
+    void accept_forbidden() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", applicationId)
+                        .header("Authorization", applicant2Token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("APPLICATION_004"));
+    }
+
+    @Test
+    @DisplayName("신청 수락 실패 - 존재하지 않는 신청")
+    void accept_notFound() throws Exception {
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", 99999L)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("APPLICATION_001"));
+    }
+}

--- a/backend/src/test/java/com/techeer/carpool/domain/auth/AuthIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/auth/AuthIntegrationTest.java
@@ -1,0 +1,238 @@
+package com.techeer.carpool.domain.auth;
+
+import tools.jackson.databind.ObjectMapper;
+import com.techeer.carpool.domain.auth.entity.RefreshToken;
+import com.techeer.carpool.domain.auth.repository.RefreshTokenRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.global.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired MemberRepository memberRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    // ── 회원가입 ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signup_success() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "new@test.com",
+                                "password", "password123",
+                                "nickname", "신규유저"
+                        ))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 중복")
+    void signup_emailDuplicate() throws Exception {
+        memberRepository.save(Member.builder()
+                .email("dup@test.com").password("pw").nickname("기존유저").build());
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "dup@test.com",
+                                "password", "password123",
+                                "nickname", "중복유저"
+                        ))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("AUTH_001"));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 형식 오류")
+    void signup_invalidEmail() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "not-an-email",
+                                "password", "password123",
+                                "nickname", "유저"
+                        ))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 비밀번호 8자 미만")
+    void signup_shortPassword() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "valid@test.com",
+                                "password", "short",
+                                "nickname", "유저"
+                        ))))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── 로그인 ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("로그인 성공 - accessToken 반환, refreshToken 쿠키 설정")
+    void login_success() throws Exception {
+        memberRepository.save(Member.builder()
+                .email("user@test.com")
+                .password(passwordEncoder.encode("password123"))
+                .nickname("유저").build());
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "user@test.com",
+                                "password", "password123"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(cookie().httpOnly("refreshToken", true));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 존재하지 않는 이메일")
+    void login_memberNotFound() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "ghost@test.com",
+                                "password", "password123"
+                        ))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("AUTH_002"));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void login_wrongPassword() throws Exception {
+        memberRepository.save(Member.builder()
+                .email("user@test.com")
+                .password(passwordEncoder.encode("correctPassword"))
+                .nickname("유저").build());
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "user@test.com",
+                                "password", "wrongPassword"
+                        ))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_003"));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 탈퇴한 회원")
+    void login_withdrawnMember() throws Exception {
+        Member member = memberRepository.save(Member.builder()
+                .email("withdrawn@test.com")
+                .password(passwordEncoder.encode("password123"))
+                .nickname("탈퇴유저").build());
+        member.withdraw();
+        memberRepository.save(member);
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "withdrawn@test.com",
+                                "password", "password123"
+                        ))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("AUTH_002"));
+    }
+
+    // ── 토큰 재발급 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    void refresh_success() throws Exception {
+        Member member = memberRepository.save(Member.builder()
+                .email("user@test.com")
+                .password(passwordEncoder.encode("password123"))
+                .nickname("유저").build());
+
+        // 로그인으로 쿠키 획득
+        MvcResult loginResult = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "email", "user@test.com",
+                                "password", "password123"
+                        ))))
+                .andReturn();
+
+        Cookie refreshCookie = loginResult.getResponse().getCookie("refreshToken");
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(refreshCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(cookie().exists("refreshToken"));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 쿠키 없음")
+    void refresh_noCookie() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/refresh"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_004"));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 유효하지 않은 토큰")
+    void refresh_invalidToken() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("refreshToken", "invalid.token.value")))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_004"));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - DB에 없는 토큰 (탈취 감지)")
+    void refresh_tokenNotInDb() throws Exception {
+        Member member = memberRepository.save(Member.builder()
+                .email("user@test.com")
+                .password(passwordEncoder.encode("pw"))
+                .nickname("유저").build());
+
+        // DB에 저장되지 않은 유효한 토큰
+        String orphanToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("refreshToken", orphanToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_004"));
+    }
+}

--- a/backend/src/test/java/com/techeer/carpool/domain/member/MemberIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/member/MemberIntegrationTest.java
@@ -1,0 +1,139 @@
+package com.techeer.carpool.domain.member;
+
+import tools.jackson.databind.ObjectMapper;
+import com.techeer.carpool.domain.auth.repository.RefreshTokenRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.global.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MemberIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired MemberRepository memberRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    private Long memberId;
+    private Long otherMemberId;
+    private String token;
+    private String otherToken;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        Member member = memberRepository.save(Member.builder()
+                .email("me@test.com")
+                .password(passwordEncoder.encode("password123"))
+                .nickname("나").build());
+        memberId = member.getId();
+        token = "Bearer " + jwtTokenProvider.createAccessToken(memberId);
+
+        Member other = memberRepository.save(Member.builder()
+                .email("other@test.com")
+                .password(passwordEncoder.encode("password123"))
+                .nickname("타인").build());
+        otherMemberId = other.getId();
+        otherToken = "Bearer " + jwtTokenProvider.createAccessToken(otherMemberId);
+    }
+
+    // ── 프로필 조회 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("내 프로필 조회 성공")
+    void getMyProfile_success() throws Exception {
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value("me@test.com"))
+                .andExpect(jsonPath("$.data.nickname").value("나"));
+    }
+
+    @Test
+    @DisplayName("프로필 조회 실패 - 미인증")
+    void getMyProfile_unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/v1/members/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("ID로 내 프로필 조회 성공")
+    void getProfileById_self() throws Exception {
+        mockMvc.perform(get("/api/v1/members/{id}", memberId)
+                        .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(memberId));
+    }
+
+    @Test
+    @DisplayName("ID로 타인 프로필 조회 실패 - 403")
+    void getProfileById_other_forbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/members/{id}", otherMemberId)
+                        .header("Authorization", token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("MEMBER_001"));
+    }
+
+    // ── 프로필 수정 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("닉네임 수정 성공")
+    void updateProfile_nickname() throws Exception {
+        mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "nickname", "새닉네임"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("새닉네임"));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    void updateProfile_password() throws Exception {
+        mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "currentPassword", "password123",
+                                "newPassword", "newPassword456"
+                        ))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 현재 비밀번호 불일치")
+    void updateProfile_wrongCurrentPassword() throws Exception {
+        mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "currentPassword", "wrongPassword",
+                                "newPassword", "newPassword456"
+                        ))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_003"));
+    }
+}

--- a/backend/src/test/java/com/techeer/carpool/domain/post/PostIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/post/PostIntegrationTest.java
@@ -1,0 +1,241 @@
+package com.techeer.carpool.domain.post;
+
+import tools.jackson.databind.ObjectMapper;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.entity.PostStatus;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PostIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired PostRepository postRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+
+    private Long ownerId;
+    private Long otherId;
+    private Long postId;
+    private String ownerToken;
+    private String otherToken;
+
+    @BeforeEach
+    void setUp() {
+        postRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        Member owner = memberRepository.save(Member.builder()
+                .email("owner@test.com").password("pw").nickname("작성자").build());
+        ownerId = owner.getId();
+        ownerToken = "Bearer " + jwtTokenProvider.createAccessToken(ownerId);
+
+        Member other = memberRepository.save(Member.builder()
+                .email("other@test.com").password("pw").nickname("타인").build());
+        otherId = other.getId();
+        otherToken = "Bearer " + jwtTokenProvider.createAccessToken(otherId);
+
+        Post post = postRepository.save(Post.builder()
+                .memberId(ownerId)
+                .title("강남 → 판교")
+                .departureLocation("강남역").departureLat(37.4979).departureLng(127.0276)
+                .destinationLocation("판교역").destinationLat(37.3943).destinationLng(127.1110)
+                .departureTime(LocalDateTime.now().plusDays(1))
+                .maxPassengers(3)
+                .description("테스트")
+                .autoAccept(false)
+                .build());
+        postId = post.getId();
+    }
+
+    // ── 게시글 생성 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("게시글 생성 성공")
+    void createPost_success() throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("title", "새 카풀");
+        body.put("departureLocation", "홍대입구");
+        body.put("departureLat", 37.5572);
+        body.put("departureLng", 126.9247);
+        body.put("destinationLocation", "여의도");
+        body.put("destinationLat", 37.5215);
+        body.put("destinationLng", 126.9242);
+        body.put("departureTime", LocalDateTime.now().plusDays(2).toString());
+        body.put("maxPassengers", 2);
+        body.put("description", "직행");
+        body.put("autoAccept", false);
+
+        mockMvc.perform(post("/api/v1/posts")
+                        .header("Authorization", ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value("새 카풀"))
+                .andExpect(jsonPath("$.data.status").value("OPEN"))
+                .andExpect(jsonPath("$.data.currentPassengers").value(0))
+                .andExpect(jsonPath("$.data.nickname").value("작성자"));
+    }
+
+    @Test
+    @DisplayName("게시글 생성 실패 - 미인증")
+    void createPost_unauthenticated() throws Exception {
+        mockMvc.perform(post("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── 게시글 조회 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("게시글 전체 목록 조회 성공")
+    void getAllPosts_success() throws Exception {
+        mockMvc.perform(get("/api/v1/posts")
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].title").value("강남 → 판교"));
+    }
+
+    @Test
+    @DisplayName("게시글 목록 조회 실패 - 미인증 시 401")
+    void getAllPosts_unauthenticated_401() throws Exception {
+        mockMvc.perform(get("/api/v1/posts"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("게시글 단건 조회 성공")
+    void getPost_success() throws Exception {
+        mockMvc.perform(get("/api/v1/posts/{id}", postId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(postId))
+                .andExpect(jsonPath("$.data.title").value("강남 → 판교"));
+    }
+
+    @Test
+    @DisplayName("게시글 단건 조회 실패 - 존재하지 않는 ID")
+    void getPost_notFound() throws Exception {
+        mockMvc.perform(get("/api/v1/posts/{id}", 99999L)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_001"));
+    }
+
+    @Test
+    @DisplayName("게시글 단건 조회 실패 - 삭제된 게시글")
+    void getPost_deleted() throws Exception {
+        Post post = postRepository.findById(postId).get();
+        post.delete();
+        postRepository.save(post);
+
+        mockMvc.perform(get("/api/v1/posts/{id}", postId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_001"));
+    }
+
+    // ── 게시글 수정 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("게시글 수정 성공")
+    void updatePost_success() throws Exception {
+        Map<String, Object> body = buildUpdateBody("수정된 제목", "수정된 내용");
+        mockMvc.perform(put("/api/v1/posts/{id}", postId)
+                        .header("Authorization", ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정된 제목"));
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패 - 타인이 수정 시도")
+    void updatePost_forbidden() throws Exception {
+        Map<String, Object> body = buildUpdateBody("해킹된 제목", "");
+        mockMvc.perform(put("/api/v1/posts/{id}", postId)
+                        .header("Authorization", otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("POST_002"));
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패 - 존재하지 않는 게시글")
+    void updatePost_notFound() throws Exception {
+        Map<String, Object> body = buildUpdateBody("없는 게시글", "");
+        mockMvc.perform(put("/api/v1/posts/{id}", 99999L)
+                        .header("Authorization", ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_001"));
+    }
+
+    private Map<String, Object> buildUpdateBody(String title, String description) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("title", title);
+        body.put("departureLocation", "강남역");
+        body.put("departureLat", 37.4979);
+        body.put("departureLng", 127.0276);
+        body.put("destinationLocation", "판교역");
+        body.put("destinationLat", 37.3943);
+        body.put("destinationLng", 127.1110);
+        body.put("departureTime", LocalDateTime.now().plusDays(1).toString());
+        body.put("maxPassengers", 3);
+        body.put("description", description);
+        body.put("autoAccept", false);
+        body.put("status", "OPEN");
+        return body;
+    }
+
+    // ── 게시글 삭제 ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("게시글 삭제 성공")
+    void deletePost_success() throws Exception {
+        mockMvc.perform(delete("/api/v1/posts/{id}", postId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("게시글이 삭제되었습니다."));
+
+        // 삭제 후 조회 시 404
+        mockMvc.perform(get("/api/v1/posts/{id}", postId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 실패 - 타인이 삭제 시도")
+    void deletePost_forbidden() throws Exception {
+        mockMvc.perform(delete("/api/v1/posts/{id}", postId)
+                        .header("Authorization", otherToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("POST_002"));
+    }
+}

--- a/docs/domain-application.md
+++ b/docs/domain-application.md
@@ -1,0 +1,144 @@
+# Application 도메인
+
+`com.techeer.carpool.domain.application` — 카풀 탑승 신청 및 수락/거절 담당
+
+---
+
+## 패키지 구조
+
+```
+application/
+├── controller/  ApplicationController
+├── dto/         ApplicationResponse
+├── entity/      Application, ApplicationStatus
+├── repository/  ApplicationRepository
+└── service/     ApplicationCreateService, ApplicationReadService, ApplicationStatusService
+```
+
+---
+
+## API
+
+모든 엔드포인트는 JWT 인증 필요
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| POST | `/api/v1/posts/{postId}/applications` | 카풀 신청 |
+| GET | `/api/v1/applications/me` | 내 신청 내역 조회 |
+| GET | `/api/v1/posts/{postId}/applications` | 게시글 신청 목록 조회 (작성자만) |
+| PATCH | `/api/v1/applications/{id}/accept` | 신청 수락 (게시글 작성자만) |
+| PATCH | `/api/v1/applications/{id}/reject` | 신청 거절 (게시글 작성자만) |
+
+---
+
+## Controller
+
+### `ApplicationController`
+
+모든 메서드는 `authentication.getPrincipal()` → `memberId` 추출 후 서비스에 전달.
+
+---
+
+## Entity
+
+### `Application` — `BaseEntity` 상속
+
+테이블: `applications`
+
+| 필드 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| `id` | Long | PK, AUTO | - |
+| `postId` | Long | NOT NULL | 신청한 게시글 ID |
+| `applicantId` | Long | NOT NULL | 신청자 회원 ID |
+| `status` | ApplicationStatus | NOT NULL | 신청 상태 (기본: PENDING) |
+| `createdAt` | LocalDateTime | NOT NULL | 생성 시각 (상속) |
+| `updatedAt` | LocalDateTime | NOT NULL | 수정 시각 (상속) |
+
+**유니크 제약**: `(post_id, applicant_id)` — 동일 게시글에 중복 신청 불가 (DB 레벨)
+
+**비즈니스 메서드**
+
+| 메서드 | 설명 |
+|--------|------|
+| `accept()` | `status = ACCEPTED` |
+| `reject()` | `status = REJECTED` |
+
+### `ApplicationStatus`
+
+| 값 | 의미 |
+|----|------|
+| `PENDING` | 대기 중 (기본값) |
+| `ACCEPTED` | 수락됨 |
+| `REJECTED` | 거절됨 |
+
+---
+
+## Repository
+
+### `ApplicationRepository`
+
+| 메서드 | 용도 |
+|--------|------|
+| `existsByPostIdAndApplicantId(Long, Long)` | 중복 신청 확인 |
+| `findByApplicantIdOrderByCreatedAtDesc(Long)` | 내 신청 내역 최신순 조회 |
+| `findByPostIdOrderByCreatedAtAsc(Long)` | 게시글 신청 목록 오래된순 조회 |
+| `countByPostIdAndStatus(Long, ApplicationStatus)` | 특정 상태 신청 수 집계 |
+
+---
+
+## Service
+
+### `ApplicationCreateService`
+
+**`apply(Long postId, Long applicantId)`**
+1. `findByIdAndDeletedFalse()` — 게시글 없으면 `POST_NOT_FOUND(404)`
+2. `post.getMemberId() == applicantId` — `APPLICATION_SELF(400)` (본인 게시글 신청 불가)
+3. `post.isFull()` — `APPLICATION_POST_FULL(409)`
+4. `existsByPostIdAndApplicantId()` — `APPLICATION_DUPLICATE(409)`
+5. `Application` 저장 후 `ApplicationResponse` 반환
+
+### `ApplicationReadService`
+
+**`getMyApplications(Long applicantId)`**
+- `findByApplicantIdOrderByCreatedAtDesc()` 조회
+- 단일 nickname 조회 후 목록 반환
+
+**`getApplicationsByPost(Long postId, Long requesterId)`**
+1. 게시글 존재 확인
+2. `post.getMemberId() != requesterId` — `APPLICATION_FORBIDDEN(403)`
+3. `findByPostIdOrderByCreatedAtAsc()` 조회
+4. `memberRepository.findAllById(applicantIds)` — 배치 조회로 N+1 방지
+5. nicknameMap 구성 후 목록 반환
+
+### `ApplicationStatusService`
+
+**`accept(Long applicationId, Long requesterId)`**
+1. `findPending()` — 없으면 `APPLICATION_NOT_FOUND(404)`, 이미 처리됐으면 `APPLICATION_ALREADY_PROCESSED(409)`
+2. 게시글 존재 확인
+3. `post.getMemberId() != requesterId` — `APPLICATION_FORBIDDEN(403)`
+4. `post.isFull()` — `APPLICATION_POST_FULL(409)`
+5. `application.accept()` + `post.incrementPassengers()`
+6. `ApplicationResponse` 반환
+
+**`reject(Long applicationId, Long requesterId)`**
+1. `findPending()` — 상태 및 존재 확인
+2. 게시글 존재·권한 확인
+3. `application.reject()`
+
+> **주의**: `accept()` 호출 시 `post.incrementPassengers()`가 `currentPassengers`를 증가시키고 정원 도달 시 `status = CLOSED`로 자동 변경.
+> 현재 `Application` 수락 후 `RidePassenger` 생성 로직은 미구현 (ride 도메인 구현 시 연결 필요).
+
+---
+
+## DTO
+
+### `ApplicationResponse`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `id` | Long | 신청 ID |
+| `postId` | Long | 게시글 ID |
+| `applicantId` | Long | 신청자 ID |
+| `applicantNickname` | String | 신청자 닉네임 |
+| `status` | ApplicationStatus | 신청 상태 |
+| `createdAt` | LocalDateTime | 신청 시각 |

--- a/docs/domain-auth.md
+++ b/docs/domain-auth.md
@@ -1,0 +1,130 @@
+# Auth 도메인
+
+`com.techeer.carpool.domain.auth` — 회원가입, 로그인, Access Token 재발급 담당
+
+---
+
+## 패키지 구조
+
+```
+auth/
+├── controller/  AuthController
+├── dto/         SignupRequest, LoginRequest, TokenResponse, AuthTokens
+├── entity/      RefreshToken
+├── repository/  RefreshTokenRepository
+└── service/     MemberSignupService, MemberLoginService, TokenReissueService
+```
+
+---
+
+## API
+
+`/api/v1/auth/**` — `SecurityConfig`에서 `permitAll()` 처리, 인증 없이 접근 가능
+
+| 메서드 | 엔드포인트 | 설명 | 인증 |
+|--------|-----------|------|------|
+| POST | `/api/v1/auth/signup` | 이메일 회원가입 | 불필요 |
+| POST | `/api/v1/auth/login` | 로그인 | 불필요 |
+| POST | `/api/v1/auth/refresh` | Access Token 재발급 | 불필요 (쿠키 기반) |
+
+---
+
+## Controller
+
+### `AuthController`
+
+**`POST /signup`**
+- `@Valid SignupRequest` 검증 후 `MemberSignupService.signup()` 호출
+- 성공 시 `201 Created`
+
+**`POST /login`**
+- `MemberLoginService.login()` → `AuthTokens(accessToken, refreshToken)` 반환
+- `accessToken` → 응답 body (`TokenResponse`)
+- `refreshToken` → `setRefreshTokenCookie()` 로 쿠키 설정
+
+**`POST /refresh`**
+- `extractRefreshTokenCookie()` 로 쿠키에서 refreshToken 추출
+- `TokenReissueService.reissue()` → 새 `AuthTokens` 반환
+- 새 refreshToken 으로 쿠키 교체
+
+**`setRefreshTokenCookie()`** — Refresh Token 쿠키 설정 규칙:
+
+| 속성 | 값 |
+|------|----|
+| `HttpOnly` | `true` (JS 접근 불가, XSS 방어) |
+| `SameSite` | `Strict` (CSRF 방어) |
+| `Secure` | `${jwt.cookie-secure}` — 로컬: `false`, 배포: `true` |
+| `Path` | `/api/v1/auth` (재발급 엔드포인트에서만 쿠키 전송) |
+| `MaxAge` | `refreshTokenExpiration` 초 |
+
+**`extractRefreshTokenCookie()`** — `request.getCookies()` null 체크 후 `refreshToken` 쿠키 탐색, 없으면 `INVALID_TOKEN` 예외
+
+---
+
+## Entity
+
+### `RefreshToken`
+
+테이블: `refresh_tokens`
+
+| 필드 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| `id` | Long | PK, AUTO | - |
+| `memberId` | Long | NOT NULL | 회원 ID (FK 없이 Long) |
+| `token` | String(512) | NOT NULL, UNIQUE | Refresh Token 값 |
+| `expiresAt` | LocalDateTime | - | 만료 시각 |
+
+**`rotate(newToken, newExpiresAt)`** — 레코드 삭제 없이 token/expiresAt 교체 → Refresh Token Rotation
+
+> 회원 1명당 레코드 1개 유지. 로그인 시 기존 것 삭제 후 신규 저장, 재발급 시 `rotate()`
+
+---
+
+## Repository
+
+### `RefreshTokenRepository`
+
+| 메서드 | 용도 |
+|--------|------|
+| `findByToken(String)` | 토큰 문자열로 조회 |
+| `deleteByMemberId(Long)` | 로그인·탈퇴 시 기존 토큰 삭제 |
+
+---
+
+## Service
+
+### `MemberSignupService`
+
+**`signup(SignupRequest)`**
+1. `existsByEmail()` — 이메일 중복이면 `EMAIL_DUPLICATE(409)`
+2. BCrypt 해싱
+3. `Member` 생성 후 저장
+
+### `MemberLoginService`
+
+**`login(LoginRequest)`**
+1. `findByEmail()` — 없거나 탈퇴 회원이면 `MEMBER_NOT_FOUND(404)`
+2. `passwordEncoder.matches()` — 불일치 시 `INVALID_CREDENTIALS(401)`
+3. Access Token, Refresh Token 생성
+4. `deleteByMemberId()` → 기존 Refresh Token 삭제
+5. 새 `RefreshToken` 저장 후 `AuthTokens` 반환
+
+### `TokenReissueService`
+
+**`reissue(String refreshTokenValue)`**
+1. `validateToken()` — 유효하지 않으면 `INVALID_TOKEN(401)`
+2. `findByToken()` — DB에 없으면 `INVALID_TOKEN(401)`
+3. 새 Access Token, Refresh Token 생성
+4. `refreshToken.rotate()` — DB 토큰 교체
+5. `AuthTokens` 반환
+
+---
+
+## DTO
+
+| 클래스 | 방향 | 필드 |
+|--------|------|------|
+| `SignupRequest` | → | `email`(@Email), `password`(min 8), `nickname`(max 50) |
+| `LoginRequest` | → | `email`(@Email), `password` |
+| `TokenResponse` | ← | `accessToken` |
+| `AuthTokens` | 내부 | `record(accessToken, refreshToken)` |

--- a/docs/domain-comment.md
+++ b/docs/domain-comment.md
@@ -1,0 +1,125 @@
+# Comment 도메인
+
+`com.techeer.carpool.domain.comment` — 게시글 댓글 작성·조회·삭제 담당
+
+---
+
+## 패키지 구조
+
+```
+comment/
+├── controller/  CommentController
+├── dto/         CommentCreateRequest, CommentResponse
+├── entity/      Comment
+├── repository/  CommentRepository
+└── service/     CommentCreateService, CommentReadService, CommentDeleteService
+```
+
+---
+
+## API
+
+모든 엔드포인트는 JWT 인증 필요
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| POST | `/api/v1/posts/{postId}/comments` | 댓글 작성 |
+| GET | `/api/v1/posts/{postId}/comments` | 댓글 목록 조회 |
+| DELETE | `/api/v1/comments/{commentId}` | 댓글 삭제 — 소프트 삭제 (작성자만) |
+
+---
+
+## Controller
+
+### `CommentController`
+
+**`POST /posts/{postId}/comments`** — `authentication.getPrincipal()` → `memberId`, `@Valid` 검증 후 `201 Created`
+
+**`GET /posts/{postId}/comments`** — 인증 필요, 삭제되지 않은 댓글 오래된순 반환
+
+**`DELETE /comments/{commentId}`** — `authentication.getPrincipal()` → `memberId`, 작성자 불일치 시 `COMMENT_FORBIDDEN(403)`
+
+---
+
+## Entity
+
+### `Comment`
+
+> `BaseEntity` 상속 없음 — `createdAt` 직접 관리, `SoftDeletableEntity` 미상속
+
+테이블: `comments`
+
+| 필드 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| `id` | Long | PK, AUTO | - |
+| `postId` | Long | NOT NULL | 게시글 ID |
+| `memberId` | Long | NOT NULL | 작성자 ID |
+| `content` | String(500) | NOT NULL | 댓글 내용 |
+| `createdAt` | LocalDateTime | NOT NULL, updatable=false | 작성 시각 |
+| `deleted` | boolean | NOT NULL | 소프트 삭제 플래그 |
+
+**`@PrePersist`** — `createdAt = now()`, `deleted = false` 자동 설정
+
+**비즈니스 메서드**
+
+| 메서드 | 설명 |
+|--------|------|
+| `delete()` | `deleted = true` |
+
+---
+
+## Repository
+
+### `CommentRepository`
+
+| 메서드 | 용도 |
+|--------|------|
+| `findByPostIdAndDeletedFalseOrderByCreatedAtAsc(Long)` | 게시글의 활성 댓글 오래된순 조회 |
+| `findByIdAndDeletedFalse(Long)` | ID로 활성 댓글 단건 조회 |
+
+---
+
+## Service
+
+### `CommentCreateService`
+
+**`createComment(Long postId, CommentCreateRequest, Long memberId)`**
+1. 게시글 존재 확인 — `POST_NOT_FOUND(404)`
+2. `Comment` 생성 및 저장
+3. 닉네임 조회 후 `CommentResponse` 반환
+
+### `CommentReadService`
+
+**`getCommentsByPostId(Long postId)`**
+1. 게시글 존재 확인 — `POST_NOT_FOUND(404)`
+2. `findByPostIdAndDeletedFalseOrderByCreatedAtAsc()` 조회
+3. `memberRepository.findAllById(memberIds)` — 배치 조회로 N+1 방지
+4. nicknameMap 구성 후 `CommentResponse` 목록 반환
+
+### `CommentDeleteService`
+
+**`deleteComment(Long commentId, Long memberId)`**
+1. `findByIdAndDeletedFalse()` — `COMMENT_NOT_FOUND(404)`
+2. `comment.getMemberId() != memberId` — `COMMENT_FORBIDDEN(403)`
+3. `comment.delete()`
+
+---
+
+## DTO
+
+### `CommentCreateRequest`
+
+| 필드 | 제약 | 설명 |
+|------|------|------|
+| `content` | @NotBlank, max 500 | 댓글 내용 |
+
+### `CommentResponse`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `id` | Long | 댓글 ID |
+| `postId` | Long | 게시글 ID |
+| `memberId` | Long | 작성자 ID |
+| `nickname` | String | 작성자 닉네임 |
+| `content` | String | 댓글 내용 |
+| `createdAt` | LocalDateTime | 작성 시각 |

--- a/docs/domain-member.md
+++ b/docs/domain-member.md
@@ -1,0 +1,136 @@
+# Member 도메인
+
+`com.techeer.carpool.domain.member` — 회원 프로필 조회·수정, 회원 탈퇴 담당
+
+---
+
+## 패키지 구조
+
+```
+member/
+├── controller/  MemberController
+├── dto/         ProfileResponse, ProfileUpdateRequest
+├── entity/      Member
+├── repository/  MemberRepository
+└── service/     MemberProfileService, MemberWithdrawService
+```
+
+---
+
+## API
+
+모든 엔드포인트는 JWT 인증 필요 (`anyRequest().authenticated()`)
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| GET | `/api/v1/members/me` | 내 프로필 조회 |
+| GET | `/api/v1/members/{id}` | ID로 프로필 조회 (본인만 가능) |
+| PUT | `/api/v1/members/me` | 프로필 수정 (닉네임, 비밀번호) |
+| DELETE | `/api/v1/members/me` | 회원 탈퇴 (소프트 삭제) |
+
+---
+
+## Controller
+
+### `MemberController`
+
+**`GET /me`**
+- `authentication.getPrincipal()` → `memberId`
+- `getProfile(memberId, memberId)` 호출
+
+**`GET /{id}`**
+- `authentication.getPrincipal()` → `requesterId`
+- `getProfile(requesterId, id)` 호출
+- `requesterId != id` 면 `MEMBER_FORBIDDEN(403)` — 본인 프로필만 조회 가능
+
+**`PUT /me`**
+- `authentication.getPrincipal()` → `memberId`
+- `@Valid ProfileUpdateRequest` 검증 후 `updateProfile(memberId, request)` 호출
+
+**`DELETE /me`**
+- `authentication.getPrincipal()` → `memberId`
+- `MemberWithdrawService.withdraw(memberId)` 호출
+
+---
+
+## Entity
+
+### `Member` — `SoftDeletableEntity` 상속
+
+테이블: `members`
+
+| 필드 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| `id` | Long | PK, AUTO | - |
+| `email` | String(100) | NOT NULL, UNIQUE | 이메일 |
+| `password` | String(60) | NOT NULL | BCrypt 해시 |
+| `nickname` | String(50) | NOT NULL | 닉네임 |
+| `deleted` | boolean | NOT NULL | 소프트 삭제 플래그 (상속) |
+| `createdAt` | LocalDateTime | NOT NULL | 생성 시각 (상속) |
+| `updatedAt` | LocalDateTime | NOT NULL | 수정 시각 (상속) |
+
+**비즈니스 메서드**
+
+| 메서드 | 설명 |
+|--------|------|
+| `updateNickname(String)` | 닉네임 변경 |
+| `updatePassword(String)` | 인코딩된 비밀번호로 교체 |
+| `withdraw()` | `delete()` 위임 → `deleted = true` |
+
+---
+
+## Repository
+
+### `MemberRepository`
+
+| 메서드 | 용도 |
+|--------|------|
+| `findByEmail(String)` | 이메일로 회원 조회 |
+| `findByIdAndDeletedFalse(Long)` | ID로 활성 회원 조회 |
+| `existsByEmail(String)` | 이메일 중복 확인 |
+
+---
+
+## Service
+
+### `MemberProfileService`
+
+**`getProfile(Long requesterId, Long memberId)`**
+1. `requesterId != memberId` — `MEMBER_FORBIDDEN(403)`
+2. `findByIdAndDeletedFalse()` — 없으면 `MEMBER_NOT_FOUND(404)`
+3. `ProfileResponse.from(member)` 반환
+
+**`updateProfile(Long memberId, ProfileUpdateRequest request)`**
+- `nickname` 존재 시: `member.updateNickname()`
+- `newPassword` 존재 시:
+  - `currentPassword` 없거나 불일치 → `INVALID_CREDENTIALS(401)`
+  - `member.updatePassword(BCrypt 해싱)`
+- 변경 감지로 자동 저장 (`@Transactional`)
+
+### `MemberWithdrawService`
+
+**`withdraw(Long memberId)`**
+1. `findByIdAndDeletedFalse()` — 없으면 `MEMBER_NOT_FOUND(404)`
+2. `member.withdraw()` — `deleted = true`
+3. `refreshTokenRepository.deleteByMemberId()` — Refresh Token 삭제
+
+---
+
+## DTO
+
+### `ProfileResponse`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `id` | Long | 회원 ID |
+| `email` | String | 이메일 |
+| `nickname` | String | 닉네임 |
+| `createdAt` | LocalDateTime | 가입 시각 |
+
+### `ProfileUpdateRequest`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `nickname` | String | 변경할 닉네임 (nullable) |
+| `currentPassword` | String | 현재 비밀번호 (비밀번호 변경 시 필요) |
+| `newPassword` | String | 변경할 비밀번호 (nullable) |

--- a/docs/domain-post.md
+++ b/docs/domain-post.md
@@ -1,0 +1,170 @@
+# Post 도메인
+
+`com.techeer.carpool.domain.post` — 카풀 모집 게시글 CRUD 담당
+
+---
+
+## 패키지 구조
+
+```
+post/
+├── controller/  PostController
+├── dto/         PostCreateRequest, PostUpdateRequest, PostResponse
+├── entity/      Post, PostStatus
+├── repository/  PostRepository
+└── service/     PostCreateService, PostReadService, PostUpdateService, PostDeleteService
+```
+
+---
+
+## API
+
+모든 엔드포인트는 JWT 인증 필요
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| POST | `/api/v1/posts` | 게시글 생성 |
+| GET | `/api/v1/posts` | 전체 목록 조회 (최신순) |
+| GET | `/api/v1/posts/{id}` | 단건 조회 |
+| PUT | `/api/v1/posts/{id}` | 게시글 수정 (작성자만) |
+| DELETE | `/api/v1/posts/{id}` | 게시글 삭제 — 소프트 삭제 (작성자만) |
+
+---
+
+## Controller
+
+### `PostController`
+
+**`POST /`** — `authentication.getPrincipal()` → `memberId` → `createPost(request, memberId)` → `201 Created`
+
+**`GET /`** — 인증 필요, `getAllPosts()` → 최신순 목록
+
+**`GET /{id}`** — `getPostById(id)`
+
+**`PUT /{id}`** — `authentication.getPrincipal()` → `memberId`, 작성자 불일치 시 `POST_FORBIDDEN(403)`
+
+**`DELETE /{id}`** — `authentication.getPrincipal()` → `memberId`, 소프트 삭제
+
+---
+
+## Entity
+
+### `Post` — `SoftDeletableEntity` 상속
+
+테이블: `posts`
+
+| 필드 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| `id` | Long | PK, AUTO | - |
+| `memberId` | Long | NOT NULL | 작성자 ID |
+| `title` | String(100) | NOT NULL | 제목 |
+| `departureLocation` | String(100) | NOT NULL | 출발지 이름 |
+| `departureLat` | Double | - | 출발지 위도 |
+| `departureLng` | Double | - | 출발지 경도 |
+| `destinationLocation` | String(100) | NOT NULL | 목적지 이름 |
+| `destinationLat` | Double | - | 목적지 위도 |
+| `destinationLng` | Double | - | 목적지 경도 |
+| `departureTime` | LocalDateTime | NOT NULL | 출발 시각 |
+| `maxPassengers` | int | NOT NULL | 최대 탑승 인원 |
+| `currentPassengers` | int | NOT NULL | 현재 탑승 신청 인원 |
+| `status` | PostStatus | NOT NULL | 게시글 상태 (기본: OPEN) |
+| `description` | TEXT | - | 게시글 본문 |
+| `autoAccept` | boolean | NOT NULL | 자동 수락 여부 |
+| `price` | Integer | - | 금액 |
+| `tags` | List\<String\> | - | 태그 목록 (`post_tags` 테이블) |
+| `deleted` | boolean | NOT NULL | 소프트 삭제 (상속) |
+| `createdAt` | LocalDateTime | NOT NULL | 생성 시각 (상속) |
+| `updatedAt` | LocalDateTime | NOT NULL | 수정 시각 (상속) |
+
+**`@PrePersist`** — 저장 전 `status = OPEN`, `currentPassengers = 0` 자동 설정
+
+**비즈니스 메서드**
+
+| 메서드 | 설명 |
+|--------|------|
+| `isFull()` | `currentPassengers >= maxPassengers` |
+| `incrementPassengers()` | `currentPassengers++`, 정원 도달 시 `status = CLOSED` |
+| `updateFrom(PostUpdateRequest)` | 모든 수정 가능 필드 일괄 업데이트 |
+
+### `PostStatus`
+
+| 값 | 의미 |
+|----|------|
+| `OPEN` | 모집 중 (기본값) |
+| `CLOSED` | 정원 마감 |
+| `CANCELLED` | 취소됨 |
+
+---
+
+## Repository
+
+### `PostRepository`
+
+| 메서드 | 용도 |
+|--------|------|
+| `findByDeletedFalseOrderByCreatedAtDesc()` | 삭제되지 않은 게시글 최신순 전체 조회 |
+| `findByIdAndDeletedFalse(Long)` | ID로 활성 게시글 단건 조회 |
+
+---
+
+## Service
+
+### `PostCreateService`
+
+**`createPost(PostCreateRequest, Long memberId)`**
+1. `Post.builder()` 로 엔티티 생성 후 저장
+2. `memberRepository.findById()` 로 닉네임 조회
+3. `PostResponse.from(saved, nickname)` 반환
+
+### `PostReadService` — `@Transactional(readOnly = true)`
+
+**`getAllPosts()`**
+1. `findByDeletedFalseOrderByCreatedAtDesc()` — 전체 조회
+2. `memberRepository.findAllById(memberIds)` — 배치 조회로 N+1 방지
+3. nicknameMap 구성 후 `PostResponse` 목록 반환
+
+**`getPostById(Long id)`**
+1. `findByIdAndDeletedFalse()` — 없으면 `POST_NOT_FOUND(404)`
+2. 개별 nickname 조회 후 `PostResponse` 반환
+
+### `PostUpdateService`
+
+**`updatePost(Long id, PostUpdateRequest, Long requesterId)`**
+1. `findByIdAndDeletedFalse()` — 없으면 `POST_NOT_FOUND(404)`
+2. `memberId != requesterId` — `POST_FORBIDDEN(403)`
+3. `post.updateFrom(request)` — 변경 감지로 자동 저장
+
+### `PostDeleteService`
+
+**`deletePost(Long id, Long requesterId)`**
+1. `findByIdAndDeletedFalse()` — 없으면 `POST_NOT_FOUND(404)`
+2. `memberId != requesterId` — `POST_FORBIDDEN(403)`
+3. `post.delete()` — `deleted = true`
+
+---
+
+## DTO
+
+### `PostCreateRequest`
+
+| 필드 | 타입 |
+|------|------|
+| `title` | String |
+| `departureLocation` | String |
+| `departureLat`, `departureLng` | Double |
+| `destinationLocation` | String |
+| `destinationLat`, `destinationLng` | Double |
+| `departureTime` | LocalDateTime |
+| `maxPassengers` | int |
+| `description` | String |
+| `autoAccept` | boolean |
+| `price` | Integer |
+| `tags` | List\<String\> |
+
+### `PostUpdateRequest`
+
+`PostCreateRequest` 필드 + `status(PostStatus)` 추가 — 상태 직접 변경 가능
+
+### `PostResponse`
+
+`PostCreateRequest` 필드 + `id`, `memberId`, `nickname`, `currentPassengers`, `status`, `createdAt`, `updatedAt`

--- a/docs/domain-ride.md
+++ b/docs/domain-ride.md
@@ -1,0 +1,189 @@
+# Ride 도메인
+
+`com.techeer.carpool.domain.ride` — 실제 운행 관리 담당 (미완성, 향후 구현 예정)
+
+---
+
+## 패키지 구조
+
+```
+ride/
+├── controller/  RideController
+├── dto/         RideDto (CreateRequest, RideResponse, LocationResponse, PassengerResponse, LocationUpdateRequest)
+├── entity/      Ride, RidePassenger, RideStatus, PassengerStatus
+├── repository/  RideRepository, RidePassengerRepository
+└── service/     RideService
+```
+
+---
+
+## API
+
+모든 엔드포인트는 JWT 인증 필요
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| POST | `/api/v1/rides` | 운행 생성 |
+| GET | `/api/v1/rides/{rideId}` | 운행 단건 조회 |
+| POST | `/api/v1/rides/{rideId}/start` | 운행 시작 |
+| POST | `/api/v1/rides/{rideId}/complete` | 운행 종료 |
+| POST | `/api/v1/rides/{rideId}/location` | 드라이버 위치 업데이트 |
+| GET | `/api/v1/rides/{rideId}/location` | 드라이버 현재 위치 조회 |
+| GET | `/api/v1/rides/{rideId}/passengers` | 탑승자 목록 조회 |
+| POST | `/api/v1/rides/{rideId}/passengers/{applicationId}/board` | 탑승 확인 |
+| POST | `/api/v1/rides/{rideId}/passengers/{applicationId}/dropoff` | 하차 확인 |
+
+> **주의**: 현재 Controller에 `Authentication` 미적용. 드라이버 권한 검증 없음. 향후 구현 시 추가 필요.
+
+---
+
+## 상태 흐름
+
+```
+Ride:          SCHEDULED → IN_PROGRESS → COMPLETED
+RidePassenger: PENDING   → BOARDED     → DROPPED_OFF
+```
+
+---
+
+## Entity
+
+### `Ride` — `BaseEntity` 상속
+
+테이블: `rides`
+
+| 필드 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| `id` | Long | PK, AUTO | - |
+| `postId` | Long | NOT NULL | 기반 게시글 ID |
+| `driverId` | Long | NOT NULL | 드라이버 회원 ID |
+| `status` | RideStatus | NOT NULL | 운행 상태 (기본: SCHEDULED) |
+| `currentLatitude` | Double | - | 드라이버 현재 위도 |
+| `currentLongitude` | Double | - | 드라이버 현재 경도 |
+| `startedAt` | LocalDateTime | - | 운행 시작 시각 |
+| `completedAt` | LocalDateTime | - | 운행 종료 시각 |
+| `passengers` | List\<RidePassenger\> | CASCADE ALL | 탑승자 목록 (1:N) |
+| `createdAt` | LocalDateTime | NOT NULL | 생성 시각 (상속) |
+| `updatedAt` | LocalDateTime | NOT NULL | 수정 시각 (상속) |
+
+**비즈니스 메서드**
+
+| 메서드 | 선행 조건 | 동작 |
+|--------|----------|------|
+| `start()` | `status == SCHEDULED` | `status = IN_PROGRESS`, `startedAt = now()` |
+| `complete()` | `status == IN_PROGRESS` | `status = COMPLETED`, `completedAt = now()` |
+| `updateLocation(lat, lng)` | `status == IN_PROGRESS` | 위도/경도 갱신 |
+
+> 조건 불충족 시 `IllegalStateException` throw (서비스 레이어의 `RIDE_INVALID_STATUS` 체크가 선행됨)
+
+### `RidePassenger` — `BaseEntity` 상속
+
+테이블: `ride_passengers`
+
+| 필드 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| `id` | Long | PK, AUTO | - |
+| `ride` | Ride | FK ride_id, NOT NULL | 소속 운행 (ManyToOne LAZY) |
+| `applicationId` | Long | NOT NULL | 관련 신청 ID |
+| `passengerId` | Long | NOT NULL | 탑승자 회원 ID |
+| `status` | PassengerStatus | NOT NULL | 탑승 상태 (기본: PENDING) |
+| `boardedAt` | LocalDateTime | - | 탑승 확인 시각 |
+| `droppedOffAt` | LocalDateTime | - | 하차 확인 시각 |
+
+**비즈니스 메서드**
+
+| 메서드 | 선행 조건 | 동작 |
+|--------|----------|------|
+| `board()` | `status == PENDING` | `status = BOARDED`, `boardedAt = now()` |
+| `dropOff()` | `status == BOARDED` | `status = DROPPED_OFF`, `droppedOffAt = now()` |
+
+### `RideStatus`
+
+| 값 | 의미 |
+|----|------|
+| `SCHEDULED` | 예정 (기본값) |
+| `IN_PROGRESS` | 운행 중 |
+| `COMPLETED` | 완료 |
+
+### `PassengerStatus`
+
+| 값 | 의미 |
+|----|------|
+| `PENDING` | 대기 (기본값) |
+| `BOARDED` | 탑승 확인 |
+| `DROPPED_OFF` | 하차 확인 |
+
+---
+
+## Repository
+
+### `RideRepository`
+
+| 메서드 | 용도 |
+|--------|------|
+| `findByDriverIdOrderByCreatedAtDesc(Long)` | 드라이버의 운행 목록 최신순 조회 |
+
+### `RidePassengerRepository`
+
+| 메서드 | 용도 |
+|--------|------|
+| `findByRideIdAndApplicationId(Long, Long)` | rideId + applicationId로 탑승자 조회 |
+| `findByPassengerIdOrderByCreatedAtDesc(Long)` | 탑승자의 탑승 내역 최신순 조회 |
+
+---
+
+## Service
+
+### `RideService` — `@Transactional(readOnly = true)`
+
+**`createRide(RideDto.CreateRequest)`**
+1. `findByIdAndDeletedFalse(postId)` — `POST_NOT_FOUND(404)`
+2. `post.getMemberId() != request.getDriverId()` — `RIDE_FORBIDDEN(403)`
+3. `post.getStatus() != OPEN` — `RIDE_INVALID_STATUS(409)`
+4. `Ride` 생성 후 저장
+
+**`getRide(Long rideId)`** — `RIDE_NOT_FOUND(404)`
+
+**`startRide(Long rideId)`** — Ride 조회 후 `ride.start()`
+
+**`completeRide(Long rideId)`** — Ride 조회 후 `ride.complete()`
+
+**`updateLocation(Long rideId, LocationUpdateRequest)`** — `ride.updateLocation(lat, lng)`
+
+**`getLocation(Long rideId)`** — 현재 위도/경도 반환
+
+**`getPassengers(Long rideId)`** — 탑승자 목록 반환
+
+**`boardPassenger(Long rideId, Long applicationId)`**
+1. `ride.getStatus() != IN_PROGRESS` — `RIDE_INVALID_STATUS(409)`
+2. 탑승자 조회 — `RIDE_PASSENGER_NOT_FOUND(404)`
+3. `passenger.board()`
+
+**`dropOffPassenger(Long rideId, Long applicationId)`**
+1. `ride.getStatus() != IN_PROGRESS` — `RIDE_INVALID_STATUS(409)`
+2. 탑승자 조회 — `RIDE_PASSENGER_NOT_FOUND(404)`
+3. `passenger.dropOff()`
+
+---
+
+## DTO
+
+### `RideDto` (중첩 클래스 모음)
+
+| 클래스 | 방향 | 주요 필드 |
+|--------|------|----------|
+| `CreateRequest` | → | `postId`, `driverId` |
+| `LocationUpdateRequest` | → | `latitude`, `longitude` |
+| `RideResponse` | ← | `id`, `postId`, `driverId`, `status`, `currentLatitude`, `currentLongitude`, `startedAt`, `completedAt` |
+| `LocationResponse` | ← | `rideId`, `driverLatitude`, `driverLongitude` |
+| `PassengerResponse` | ← | `id`, `applicationId`, `passengerId`, `status`, `boardedAt`, `droppedOffAt` |
+
+---
+
+## 미구현 / 향후 과제
+
+| 항목 | 설명 |
+|------|------|
+| Application → RidePassenger 연결 | `ApplicationStatusService.accept()` 시 `RidePassenger` 자동 생성 로직 없음 |
+| Controller Authentication 적용 | 드라이버 권한 검증을 위해 `Authentication` 파라미터 추가 필요 |
+| 내 운행 목록 API | `GET /rides/me` (드라이버 기준), `GET /rides/me/passenger` (탑승자 기준) 미구현 |

--- a/docs/global.md
+++ b/docs/global.md
@@ -1,0 +1,204 @@
+# Global 패키지
+
+`com.techeer.carpool.global` — 전 도메인에서 공유하는 공통 설정, 유틸리티, 인프라 담당
+
+---
+
+## 패키지 구조
+
+```
+global/
+├── common/
+│   ├── ApiResponse.java
+│   └── entity/
+│       ├── BaseEntity.java
+│       └── SoftDeletableEntity.java
+├── config/
+│   ├── SecurityConfig.java
+│   └── PasswordConfig.java
+├── exception/
+│   ├── CarpoolException.java
+│   ├── ErrorCode.java
+│   └── GlobalExceptionHandler.java
+├── init/
+│   └── LocalDataInitializer.java
+└── jwt/
+    ├── JwtTokenProvider.java
+    └── JwtAuthenticationFilter.java
+```
+
+---
+
+## common
+
+### `ApiResponse<T>`
+
+모든 API 응답의 공통 래퍼.
+
+```json
+{ "message": "...", "data": { ... } }
+```
+
+| 팩토리 메서드 | 용도 |
+|-------------|------|
+| `of(String message, T data)` | 데이터 포함 응답 |
+| `of(String message)` | 메시지만 있는 응답 (data = null) |
+
+### `BaseEntity`
+
+| 필드 | 어노테이션 | 설명 |
+|------|-----------|------|
+| `createdAt` | `@CreationTimestamp`, updatable=false | 생성 시각 자동 설정 |
+| `updatedAt` | `@UpdateTimestamp` | 수정 시각 자동 갱신 |
+
+상속 대상: `Application`, `Ride`, `RidePassenger`, `RefreshToken`
+
+### `SoftDeletableEntity` — `BaseEntity` 상속
+
+| 필드 | 기본값 | 설명 |
+|------|--------|------|
+| `deleted` | `false` | 소프트 삭제 플래그 |
+
+**`delete()`** — `deleted = true`
+
+상속 대상: `Member`, `Post`
+
+> `Comment`는 `SoftDeletableEntity`를 상속하지 않고 `deleted` 필드를 직접 구현함 (코드 불일치)
+
+---
+
+## config
+
+### `SecurityConfig`
+
+**인증 규칙**
+
+| 경로 | 접근 |
+|------|------|
+| `/api/v1/auth/**` | `permitAll()` — 인증 불필요 |
+| 그 외 모든 경로 | `authenticated()` — JWT 필요 |
+
+**기타 설정**
+
+| 항목 | 설정 |
+|------|------|
+| CSRF | 비활성화 |
+| Session | `STATELESS` |
+| CORS | `http://localhost:5173` 허용, 모든 메서드/헤더, `allowCredentials=true` |
+| Filter | `JwtAuthenticationFilter` → `UsernamePasswordAuthenticationFilter` 앞에 추가 |
+
+### `PasswordConfig`
+
+`BCryptPasswordEncoder` 빈 등록.
+
+`SecurityConfig`와의 순환 의존성 방지를 위해 별도 설정 클래스로 분리.
+
+---
+
+## exception
+
+### `CarpoolException`
+
+`RuntimeException` 상속. `ErrorCode`를 감싸는 커스텀 예외.
+
+```java
+throw new CarpoolException(ErrorCode.POST_NOT_FOUND);
+```
+
+### `ErrorCode`
+
+| 코드 | 상수명 | HTTP | 메시지 |
+|------|--------|------|--------|
+| POST_001 | `POST_NOT_FOUND` | 404 | 게시글을 찾을 수 없습니다. |
+| POST_002 | `POST_FORBIDDEN` | 403 | 게시글 수정/삭제 권한이 없습니다. |
+| COMMENT_001 | `COMMENT_NOT_FOUND` | 404 | 댓글을 찾을 수 없습니다. |
+| COMMENT_002 | `COMMENT_FORBIDDEN` | 403 | 댓글 삭제 권한이 없습니다. |
+| APPLICATION_001 | `APPLICATION_NOT_FOUND` | 404 | 신청을 찾을 수 없습니다. |
+| APPLICATION_002 | `APPLICATION_DUPLICATE` | 409 | 이미 신청한 게시글입니다. |
+| APPLICATION_003 | `APPLICATION_SELF` | 400 | 본인 게시글에는 신청할 수 없습니다. |
+| APPLICATION_004 | `APPLICATION_FORBIDDEN` | 403 | 신청 수락/거절 권한이 없습니다. |
+| APPLICATION_005 | `APPLICATION_POST_FULL` | 409 | 정원이 가득 찬 게시글입니다. |
+| APPLICATION_006 | `APPLICATION_ALREADY_PROCESSED` | 409 | 이미 처리된 신청입니다. |
+| COMMON_001 | `INVALID_INPUT` | 400 | 잘못된 입력값입니다. |
+| AUTH_001 | `EMAIL_DUPLICATE` | 409 | 이미 사용 중인 이메일입니다. |
+| AUTH_002 | `MEMBER_NOT_FOUND` | 404 | 사용자를 찾을 수 없습니다. |
+| AUTH_003 | `INVALID_CREDENTIALS` | 401 | 이메일 또는 비밀번호가 올바르지 않습니다. |
+| AUTH_004 | `INVALID_TOKEN` | 401 | 유효하지 않은 토큰입니다. |
+| AUTH_005 | `EXPIRED_TOKEN` | 401 | 만료된 토큰입니다. |
+| RIDE_001 | `RIDE_NOT_FOUND` | 404 | 운행을 찾을 수 없습니다. |
+| RIDE_002 | `RIDE_FORBIDDEN` | 403 | 운행 제어 권한이 없습니다. |
+| RIDE_003 | `RIDE_INVALID_STATUS` | 409 | 현재 상태에서 허용되지 않는 작업입니다. |
+| RIDE_004 | `RIDE_PASSENGER_NOT_FOUND` | 404 | 탑승자를 찾을 수 없습니다. |
+| MEMBER_001 | `MEMBER_FORBIDDEN` | 403 | 본인의 프로필만 조회할 수 있습니다. |
+
+### `GlobalExceptionHandler`
+
+`@RestControllerAdvice` — 전역 예외 처리
+
+**에러 응답 형식**
+```json
+{ "code": "POST_001", "message": "게시글을 찾을 수 없습니다." }
+```
+
+| 핸들러 | 대상 | 응답 |
+|--------|------|------|
+| `handleCarpoolException` | `CarpoolException` | `ErrorCode`의 status + code + message |
+| `handleValidationException` | `MethodArgumentNotValidException` | 400, COMMON_001, 첫 번째 필드 에러 메시지 |
+| `handleGeneralException` | `Exception` (fallback) | 500, SERVER_ERROR |
+
+---
+
+## init
+
+### `LocalDataInitializer`
+
+`@Profile("local")` — 로컬 환경에서만 동작 (`CommandLineRunner`)
+
+앱 시작 시 자동 실행:
+- `test@carpool.com` / `password1234` / 테스트유저
+- `admin@carpool.com` / `admin1234!` / 관리자
+- 게시글 3개 (강남→판교, 홍대→여의도, 서울역→수원역) + 각 게시글에 댓글 3개
+
+`createMemberIfNotExists()` — 이미 존재하면 재생성하지 않음 (멱등성 보장)
+
+---
+
+## jwt
+
+### `JwtTokenProvider`
+
+설정값 (`application.yml`):
+
+| 프로퍼티 | 설명 |
+|---------|------|
+| `jwt.secret` | HMAC-SHA 서명 키 (환경변수 `${JWT_SECRET}` 권장) |
+| `jwt.access-token-expiration` | Access Token 만료 시간 (ms) |
+| `jwt.refresh-token-expiration` | Refresh Token 만료 시간 (ms) |
+| `jwt.cookie-secure` | Refresh Token 쿠키 Secure 속성 (로컬: false) |
+
+**주요 메서드**
+
+| 메서드 | 설명 |
+|--------|------|
+| `createAccessToken(Long memberId)` | Access Token 생성 |
+| `createRefreshToken(Long memberId)` | Refresh Token 생성 |
+| `validateToken(String)` | 토큰 서명·만료 검증, boolean 반환 |
+| `getMemberIdFromToken(String)` | 토큰 payload의 `memberId` 클레임 추출 |
+| `getRefreshTokenExpiresAt()` | `LocalDateTime.now() + refreshExpiration` |
+| `getRefreshTokenExpirationSeconds()` | 쿠키 maxAge 설정용 초 단위 값 |
+
+토큰 payload: `{ "memberId": Long, "iat": ..., "exp": ... }`
+
+### `JwtAuthenticationFilter`
+
+`OncePerRequestFilter` 상속 — 요청당 1회 실행
+
+**처리 흐름**:
+1. `Authorization: Bearer <token>` 헤더에서 토큰 추출
+2. `jwtTokenProvider.validateToken()` — 유효하면
+3. `getMemberIdFromToken()` → `memberId` 추출
+4. `UsernamePasswordAuthenticationToken(memberId, null, [])` 생성
+5. `SecurityContextHolder`에 저장
+6. `filterChain.doFilter()` — 다음 필터로 전달
+
+컨트롤러에서 `authentication.getPrincipal()` 호출 시 `Long memberId` 반환.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,0 +1,165 @@
+# 알려진 이슈 & 개선 목록
+
+심각도: 🔴 보안/버그 → 🟡 설계 결함 → 🟢 개선 사항  
+상태: ✅ 해결됨 | 🔧 미해결
+
+---
+
+## 🔴 보안
+
+### [SEC-01] ✅ 게시글 생성 시 memberId를 Authentication에서 추출
+`PostController`에서 `authentication.getPrincipal()` 으로 memberId 추출. `PostCreateRequest`에 memberId 없음. **해결됨.**
+
+---
+
+### [SEC-02] 🔧 Ride 생성 시 driverId를 Request Body로 받음
+**파일:** `RideDto.java (CreateRequest)`
+
+`RideDto.CreateRequest`에 `driverId` 필드가 있어 클라이언트가 타인의 ID로 운행 생성 가능. `RideController`에 `Authentication` 미적용.
+
+**수정 방향:** `CreateRequest`에서 `driverId` 제거, `Authentication`에서 추출.
+
+---
+
+### [SEC-03] ✅ GET /api/v1/posts 인증 필요
+비인증 사용자의 게시글 목록/단건 조회 차단. `SecurityConfig`에서 `permitAll()` 제거. **해결됨.**
+
+---
+
+### [SEC-04] ✅ 타인 프로필 조회 차단
+`MemberProfileService.getProfile()`에 `requesterId == memberId` 소유권 검증 추가. `MEMBER_FORBIDDEN(403)` 반환. **해결됨.**
+
+---
+
+## 🔴 버그
+
+### [BUG-01] ✅ RideService 예외 500 반환 문제
+`EntityNotFoundException`, `IllegalStateException` → `CarpoolException`으로 교체. `RIDE_001~004` 에러 코드 추가. **해결됨.**
+
+---
+
+### [BUG-02] ✅ board/dropOff 시 Ride 상태 검증 없음
+`boardPassenger()`, `dropOffPassenger()` 에서 `ride.getStatus() != IN_PROGRESS` 체크 후 `RIDE_INVALID_STATUS(409)` 반환. **해결됨.**
+
+---
+
+### [BUG-03] 🔧 Post.updateFrom() 이 null 로 필드를 덮어씀
+**파일:** `Post.java (updateFrom)`
+
+`PostUpdateRequest`의 모든 필드는 nullable 인데, `updateFrom()`은 null 체크 없이 전부 덮어씀. 일부 필드만 전달 시 나머지가 null 로 초기화됨.
+
+**수정 방향:** 각 필드에 null 체크 후 선택적 업데이트.
+
+---
+
+### [BUG-04] 🔧 PostController에 @Valid 누락
+**파일:** `PostController.java`
+
+`@RequestBody PostCreateRequest request`, `@RequestBody PostUpdateRequest request` 에 `@Valid` 어노테이션이 없어 DTO 유효성 검사 미실행. `PostCreateRequest`에도 `@NotBlank` 등 검증 어노테이션 없음.
+
+**수정 방향:** `@Valid @RequestBody` 추가, `PostCreateRequest`에 검증 어노테이션 추가.
+
+---
+
+### [BUG-05] 🔧 Application 수락 시 RidePassenger 미생성
+**파일:** `ApplicationStatusService.java (accept)`
+
+`application.accept()` + `post.incrementPassengers()` 만 수행. 수락 후 `RidePassenger` 를 생성하는 코드가 없어 `getPassengers()`, `boardPassenger()`, `dropOffPassenger()` API 가 항상 빈 결과 또는 404 반환.
+
+**수정 방향:** Ride 도메인 구현 시 `accept()` 내에서 해당 `postId`의 `Ride`를 찾아 `RidePassenger` 생성.
+
+---
+
+## 🟡 설계 결함
+
+### [DESIGN-01] 🔧 RideController가 ApiResponse 래퍼 미사용
+**파일:** `RideController.java`
+
+다른 컨트롤러는 모두 `ApiResponse<T> { message, data }` 형태로 응답하지만 `RideController`는 DTO를 직접 반환.
+
+**수정 방향:** 모든 응답을 `ApiResponse.of(...)` 로 래핑.
+
+---
+
+### [DESIGN-02] 🔧 에러 응답과 성공 응답 형식 불일치
+**파일:** `GlobalExceptionHandler.java`
+
+- 성공: `{ "message": "...", "data": { ... } }`
+- 에러: `{ "code": "...", "message": "..." }`
+
+**수정 방향:** `ErrorResponse { code, message }` 타입을 정의하거나 에러도 `ApiResponse` 구조에 맞춤.
+
+---
+
+### [DESIGN-03] ✅ MemberWithdrawService 엔드포인트 연결
+`MemberController`에 `DELETE /api/v1/members/me` 엔드포인트 추가됨. **해결됨.**
+
+---
+
+### [DESIGN-04] ✅ ErrorCode Ride 관련 코드 추가
+`RIDE_001~004`, `MEMBER_001` 추가됨. **해결됨.**
+
+---
+
+### [DESIGN-05] 🔧 RideController에 드라이버 권한 검증 없음
+**파일:** `RideController.java`
+
+`start`, `complete`, `location`, `board`, `dropOff` 엔드포인트에 `Authentication` 파라미터가 없어 누구나 타인의 운행 제어 가능.
+
+**수정 방향:** 각 메서드에 `Authentication authentication` 추가, `driverId = (Long) authentication.getPrincipal()` 추출 후 서비스에 전달.
+
+---
+
+### [DESIGN-06] 🔧 Comment가 SoftDeletableEntity 미상속
+**파일:** `Comment.java`
+
+`Post`, `Member`는 `SoftDeletableEntity` 상속, `Comment`는 `deleted` 필드와 `delete()` 메서드를 직접 구현. `updatedAt` 없음, `BaseEntity` 상속도 없음.
+
+**수정 방향:** `SoftDeletableEntity` 상속으로 통일.
+
+---
+
+### [DESIGN-07] 🔧 JwtTokenProvider.validateToken() 만료/위조 구분 불가
+**파일:** `JwtTokenProvider.java`
+
+`validateToken()`이 boolean 반환. `JwtAuthenticationFilter`에서 `EXPIRED_TOKEN`과 `INVALID_TOKEN`을 구분할 수 없어 클라이언트가 항상 동일한 401 수신.
+
+**수정 방향:** `TokenValidationResult` enum 반환 또는 예외 타입 분기 처리.
+
+---
+
+### [DESIGN-08] 🔧 Application 수락 시 동시성 Race Condition
+**파일:** `ApplicationStatusService.java (accept)`
+
+정원 체크 → `incrementPassengers()` 사이에 동시 요청 시 `maxPassengers` 초과 가능.
+
+**수정 방향:** `Post` 엔티티에 `@Version` (낙관적 락) 또는 `@Lock(PESSIMISTIC_WRITE)` 적용.
+
+---
+
+## 🟢 개선 사항
+
+### [IMPROVE-01] 🔧 전체 목록 조회 페이지네이션 없음
+`getAllPosts()`가 모든 게시글을 한 번에 반환. `Pageable` 파라미터 추가 필요.
+
+---
+
+### [IMPROVE-02] 🔧 ApplicationStatusService.toResponse() N+1 쿼리
+**파일:** `ApplicationStatusService.java`
+
+`memberRepository.findById(applicantId)` 를 매번 개별 호출. 반복 수락/거절 시 N+1 발생.
+
+---
+
+### [IMPROVE-03] 🔧 엔티티 간 관계를 ID(Long)로만 참조
+`Post.memberId`, `Ride.postId`, `Ride.driverId` 등을 `@ManyToOne` 대신 Long으로 저장. JOIN 쿼리 불가, 연관 데이터 조회 시 별도 쿼리 필요.
+
+---
+
+### [IMPROVE-04] 🔧 테스트 코드 부재
+`CarpoolApplicationTests`, `CommentIntegrationTest` 외에 서비스 단위 테스트 없음. 핵심 서비스(Login, TokenReissue, ApplicationStatus 등)부터 작성 필요.
+
+---
+
+### [IMPROVE-05] 🔧 ProfileUpdateRequest 교차 필드 검증 없음
+비밀번호 변경 시 `currentPassword`와 `newPassword`를 함께 제공해야 하는 규칙이 DTO 레벨에서 검증되지 않고 서비스 로직에만 의존.


### PR DESCRIPTION
## Summary

- **#37** `GET /api/v1/posts` 비인증 접근 허용 제거 — 로그인 사용자만 게시글 조회 가능
- **#38** Ride 생성 시 Post 유효성 검증 추가 — Post 존재 여부, 작성자 일치, 상태 OPEN 확인
- **#39** RIDE 에러 코드 추가 및 RideService 예외 통일 — `EntityNotFoundException` → `CarpoolException`
- **#40** 타인 프로필 조회 차단 — `GET /members/{id}` 본인 소유 확인 + `MEMBER_FORBIDDEN` 에러 코드
- **#41** 탑승/하차 확인 시 운행 상태 검증 — `boardPassenger`, `dropOffPassenger`에서 `IN_PROGRESS` 여부 사전 확인

## Changes

| File | Change |
|------|--------|
| `SecurityConfig.java` | Remove `permitAll` for `GET /api/v1/posts` |
| `ErrorCode.java` | Add `RIDE_001~004`, `MEMBER_001` |
| `RideService.java` | Post validation in `createRide`, CarpoolException unification, Ride status guard in board/dropOff |
| `MemberProfileService.java` | Add `requesterId` param + ownership check in `getProfile` |
| `MemberController.java` | Pass `Authentication` to `GET /{id}` |

## Test plan

- [x] `./gradlew test` — all 5 existing tests pass (BUILD SUCCESSFUL)
- [ ] `POST /api/v1/posts` 비인증 → 401 확인
- [ ] `POST /api/v1/rides` (다른 작성자 postId) → 403 확인
- [ ] `POST /api/v1/rides` (CLOSED 게시글) → 409 확인
- [ ] `GET /api/v1/members/{타인id}` → 403 확인
- [ ] `POST /api/v1/rides/{id}/passengers/{appId}/board` (SCHEDULED 운행) → 409 확인

Closes #37, #38, #39, #40, #41