### PR TITLE
feat: 신청 수락/거절 취소 기능 추가 (#43)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/application/controller/ApplicationController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/controller/ApplicationController.java
@@ -60,4 +60,20 @@ public class ApplicationController {
         Long memberId = (Long) authentication.getPrincipal();
         return ResponseEntity.ok(ApiResponse.of("신청을 거절했습니다.", applicationStatusService.reject(id, memberId)));
     }
+
+    @PatchMapping("/api/v1/applications/{id}/cancel-accept")
+    public ResponseEntity<ApiResponse<ApplicationResponse>> cancelAccept(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("수락을 취소했습니다.", applicationStatusService.cancelAccept(id, memberId)));
+    }
+
+    @PatchMapping("/api/v1/applications/{id}/cancel-reject")
+    public ResponseEntity<ApiResponse<ApplicationResponse>> cancelReject(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("거절을 취소했습니다.", applicationStatusService.cancelReject(id, memberId)));
+    }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/application/entity/Application.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/entity/Application.java
@@ -44,4 +44,8 @@ public class Application extends BaseEntity {
     public void reject() {
         this.status = ApplicationStatus.REJECTED;
     }
+
+    public void resetToPending() {
+        this.status = ApplicationStatus.PENDING;
+    }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationStatusService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationStatusService.java
@@ -58,6 +58,49 @@ public class ApplicationStatusService {
         return toResponse(application);
     }
 
+    @Transactional
+    public ApplicationResponse cancelAccept(Long applicationId, Long requesterId) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.APPLICATION_NOT_FOUND));
+
+        if (application.getStatus() != ApplicationStatus.ACCEPTED) {
+            throw new CarpoolException(ErrorCode.APPLICATION_NOT_ACCEPTED);
+        }
+
+        Post post = postRepository.findByIdAndDeletedFalse(application.getPostId())
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.APPLICATION_FORBIDDEN);
+        }
+
+        application.resetToPending();
+        post.decrementPassengers();
+
+        return toResponse(application);
+    }
+
+    @Transactional
+    public ApplicationResponse cancelReject(Long applicationId, Long requesterId) {
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.APPLICATION_NOT_FOUND));
+
+        if (application.getStatus() != ApplicationStatus.REJECTED) {
+            throw new CarpoolException(ErrorCode.APPLICATION_NOT_REJECTED);
+        }
+
+        Post post = postRepository.findByIdAndDeletedFalse(application.getPostId())
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.APPLICATION_FORBIDDEN);
+        }
+
+        application.resetToPending();
+
+        return toResponse(application);
+    }
+
     private Application findPending(Long applicationId) {
         Application application = applicationRepository.findById(applicationId)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.APPLICATION_NOT_FOUND));

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -109,6 +109,15 @@ public class Post extends SoftDeletableEntity {
         }
     }
 
+    public void decrementPassengers() {
+        if (this.currentPassengers > 0) {
+            this.currentPassengers--;
+        }
+        if (this.status == PostStatus.CLOSED && this.currentPassengers < this.maxPassengers) {
+            this.status = PostStatus.OPEN;
+        }
+    }
+
     public void updateFrom(PostUpdateRequest request) {
         this.title = request.getTitle();
         this.departureLocation = request.getDepartureLocation();

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
     APPLICATION_FORBIDDEN("APPLICATION_004", "신청 수락/거절 권한이 없습니다.", HttpStatus.FORBIDDEN),
     APPLICATION_POST_FULL("APPLICATION_005", "정원이 가득 찬 게시글입니다.", HttpStatus.CONFLICT),
     APPLICATION_ALREADY_PROCESSED("APPLICATION_006", "이미 처리된 신청입니다.", HttpStatus.CONFLICT),
+    APPLICATION_NOT_ACCEPTED("APPLICATION_007", "수락된 신청이 아닙니다.", HttpStatus.CONFLICT),
+    APPLICATION_NOT_REJECTED("APPLICATION_008", "거절된 신청이 아닙니다.", HttpStatus.CONFLICT),
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),

--- a/backend/src/test/java/com/techeer/carpool/domain/application/ApplicationIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/application/ApplicationIntegrationTest.java
@@ -280,4 +280,134 @@ class ApplicationIntegrationTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("APPLICATION_001"));
     }
+
+    // ── 수락/거절 취소 ───────────────────────────────────────
+
+    @Test
+    @DisplayName("수락 취소 성공 - 상태 PENDING 복구, currentPassengers 감소")
+    void cancelAccept_success() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/cancel-accept", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
+
+        mockMvc.perform(get("/api/v1/posts/{id}", postId)
+                        .header("Authorization", ownerToken))
+                .andExpect(jsonPath("$.data.currentPassengers").value(0));
+    }
+
+    @Test
+    @DisplayName("거절 취소 성공 - 상태 PENDING 복구")
+    void cancelReject_success() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/reject", applicationId)
+                        .header("Authorization", ownerToken));
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/cancel-reject", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
+    }
+
+    @Test
+    @DisplayName("수락 취소 실패 - PENDING 상태에서 시도")
+    void cancelAccept_notAccepted() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/cancel-accept", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("APPLICATION_007"));
+    }
+
+    @Test
+    @DisplayName("거절 취소 실패 - PENDING 상태에서 시도")
+    void cancelReject_notRejected() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/cancel-reject", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("APPLICATION_008"));
+    }
+
+    @Test
+    @DisplayName("수락 취소 실패 - 권한 없음 (비작성자)")
+    void cancelAccept_forbidden() throws Exception {
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", postId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", applicationId)
+                        .header("Authorization", ownerToken));
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/cancel-accept", applicationId)
+                        .header("Authorization", applicant2Token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("APPLICATION_004"));
+    }
+
+    @Test
+    @DisplayName("수락 취소 성공 - CLOSED 게시글이 OPEN으로 복구")
+    void cancelAccept_reopensClosedPost() throws Exception {
+        Post smallPost = postRepository.save(Post.builder()
+                .memberId(ownerId)
+                .title("1인 카풀")
+                .departureLocation("강남역").departureLat(37.4979).departureLng(127.0276)
+                .destinationLocation("판교역").destinationLat(37.3943).destinationLng(127.1110)
+                .departureTime(LocalDateTime.now().plusDays(1))
+                .maxPassengers(1)
+                .autoAccept(false)
+                .build());
+        Long smallPostId = smallPost.getId();
+
+        MvcResult applyResult = mockMvc.perform(
+                post("/api/v1/posts/{postId}/applications", smallPostId)
+                        .header("Authorization", applicant1Token))
+                .andReturn();
+        Long applicationId = ((Number) JsonPath.read(
+                applyResult.getResponse().getContentAsString(), "$.data.id")).longValue();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/accept", applicationId)
+                        .header("Authorization", ownerToken));
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/cancel-accept", applicationId)
+                        .header("Authorization", ownerToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/posts/{id}", smallPostId)
+                        .header("Authorization", ownerToken))
+                .andExpect(jsonPath("$.data.status").value("OPEN"))
+                .andExpect(jsonPath("$.data.currentPassengers").value(0));
+    }
 }


### PR DESCRIPTION
## 개요

카풀 신청 수락/거절 후 되돌릴 수 없는 문제를 해결합니다.

Closes #43

## 변경 사항

- `PATCH /api/v1/applications/{id}/cancel-accept` — 수락 취소 (ACCEPTED → PENDING)
- `PATCH /api/v1/applications/{id}/cancel-reject` — 거절 취소 (REJECTED → PENDING)
- 수락 취소 시 `Post.currentPassengers` 감소 및 CLOSED → OPEN 상태 자동 복구

## 수정 파일

| 파일 | 변경 내용 |
|------|----------|
| `Application.java` | `resetToPending()` 메서드 추가 |
| `Post.java` | `decrementPassengers()` 메서드 추가 |
| `ErrorCode.java` | `APPLICATION_007`, `APPLICATION_008` 에러 코드 추가 |
| `ApplicationStatusService.java` | `cancelAccept()`, `cancelReject()` 서비스 메서드 추가 |
| `ApplicationController.java` | 취소 엔드포인트 2개 추가 |
| `ApplicationIntegrationTest.java` | 취소 관련 통합 테스트 6건 추가 |

## 테스트 체크리스트

- [x] 수락 취소 성공 → status PENDING, currentPassengers 감소
- [x] 거절 취소 성공 → status PENDING
- [x] CLOSED 게시글 수락 취소 시 OPEN으로 복구
- [x] PENDING 상태에서 수락 취소 시도 → 409 APPLICATION_007
- [x] PENDING 상태에서 거절 취소 시도 → 409 APPLICATION_008
- [x] 권한 없는 사용자 취소 시도 → 403 APPLICATION_004