### PR TITLE
feat: 드라이버 등록 기능 구현 및 mock 데이터 추가

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/application/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/repository/ApplicationRepository.java
@@ -16,4 +16,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     List<Application> findByPostIdOrderByCreatedAtAsc(Long postId);
 
     long countByPostIdAndStatus(Long postId, ApplicationStatus status);
+
+    List<Application> findByPostIdAndStatus(Long postId, ApplicationStatus status);
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/driver/repository/DriverRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/driver/repository/DriverRepository.java
@@ -9,5 +9,5 @@ public interface DriverRepository extends JpaRepository<Driver, Long> {
 
     Optional<Driver> findByMemberIdAndDeletedFalse(Long memberId);
 
-    boolean existsByCarNumber(String carNumber);
+    boolean existsByCarNumberAndDeletedFalse(String carNumber);
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/driver/service/DriverRegisterService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/driver/service/DriverRegisterService.java
@@ -30,7 +30,7 @@ public class DriverRegisterService {
             throw new CarpoolException(ErrorCode.DRIVER_ALREADY_REGISTERED);
         }
 
-        if (driverRepository.existsByCarNumber(request.getCarNumber())) {
+        if (driverRepository.existsByCarNumberAndDeletedFalse(request.getCarNumber())) {
             throw new CarpoolException(ErrorCode.CAR_NUMBER_DUPLICATE);
         }
 

--- a/backend/src/main/java/com/techeer/carpool/domain/driver/service/DriverUpdateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/driver/service/DriverUpdateService.java
@@ -25,7 +25,7 @@ public class DriverUpdateService {
                 .orElseThrow(() -> new CarpoolException(ErrorCode.DRIVER_NOT_FOUND));
 
         if (!driver.getCarNumber().equals(request.getCarNumber())
-                && driverRepository.existsByCarNumber(request.getCarNumber())) {
+                && driverRepository.existsByCarNumberAndDeletedFalse(request.getCarNumber())) {
             throw new CarpoolException(ErrorCode.CAR_NUMBER_DUPLICATE);
         }
 

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -1,5 +1,9 @@
 package com.techeer.carpool.domain.ride.service;
 
+import com.techeer.carpool.domain.application.entity.Application;
+import com.techeer.carpool.domain.application.entity.ApplicationStatus;
+import com.techeer.carpool.domain.application.repository.ApplicationRepository;
+import com.techeer.carpool.domain.driver.repository.DriverRepository;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.entity.PostStatus;
 import com.techeer.carpool.domain.post.repository.PostRepository;
@@ -26,9 +30,14 @@ public class RideService {
     private final RideRepository rideRepository;
     private final RidePassengerRepository ridePassengerRepository;
     private final PostRepository postRepository;
+    private final DriverRepository driverRepository;
+    private final ApplicationRepository applicationRepository;
 
     @Transactional
     public RideResponse createRide(RideCreateRequest request, Long driverId) {
+        driverRepository.findByMemberIdAndDeletedFalse(driverId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.DRIVER_NOT_FOUND));
+
         Post post = postRepository.findByIdAndDeletedFalse(request.getPostId())
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
         if (!post.getMemberId().equals(driverId)) {
@@ -37,11 +46,23 @@ public class RideService {
         if (post.getStatus() != PostStatus.OPEN) {
             throw new CarpoolException(ErrorCode.RIDE_INVALID_STATUS);
         }
-        Ride ride = Ride.builder()
+        Ride ride = rideRepository.save(Ride.builder()
                 .postId(request.getPostId())
                 .driverId(driverId)
-                .build();
-        return RideResponse.from(rideRepository.save(ride));
+                .build());
+
+        List<Application> accepted = applicationRepository.findByPostIdAndStatus(
+                request.getPostId(), ApplicationStatus.ACCEPTED);
+        List<RidePassenger> passengers = accepted.stream()
+                .map(app -> RidePassenger.builder()
+                        .ride(ride)
+                        .applicationId(app.getId())
+                        .passengerId(app.getApplicantId())
+                        .build())
+                .collect(Collectors.toList());
+        ridePassengerRepository.saveAll(passengers);
+
+        return RideResponse.from(ride);
     }
 
     public RideResponse getRide(Long rideId) {

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -2,6 +2,8 @@ package com.techeer.carpool.global.init;
 
 import com.techeer.carpool.domain.comment.entity.Comment;
 import com.techeer.carpool.domain.comment.repository.CommentRepository;
+import com.techeer.carpool.domain.driver.entity.Driver;
+import com.techeer.carpool.domain.driver.repository.DriverRepository;
 import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
 
@@ -33,6 +35,7 @@ public class LocalDataInitializer implements CommandLineRunner {
     private final CommentRepository commentRepository;
     private final PasswordEncoder passwordEncoder;
     private final VehicleOptionRepository vehicleOptionRepository;
+    private final DriverRepository driverRepository;
 
     @Override
     public void run(String... args) {
@@ -43,7 +46,8 @@ public class LocalDataInitializer implements CommandLineRunner {
             seedPosts(test, admin);
         }
 
-        initVehicleOptions();
+        List<VehicleOption> vehicleOptions = initVehicleOptions();
+        seedDrivers(test, admin, vehicleOptions);
         log.info("[LocalDataInitializer] 초기 데이터 생성 완료");
     }
 
@@ -122,8 +126,30 @@ public class LocalDataInitializer implements CommandLineRunner {
                         .build()));
     }
 
-    private void initVehicleOptions() {
-        if (vehicleOptionRepository.count() > 0) return;
+    private void seedDrivers(Member test, Member admin, List<VehicleOption> vehicleOptions) {
+        if (driverRepository.count() > 0) return;
+
+        // 아반떼 흰색(index 0), 소나타 검정(index 8)
+        VehicleOption testOption  = vehicleOptions.get(0);
+        VehicleOption adminOption = vehicleOptions.get(8);
+
+        driverRepository.save(Driver.builder()
+                .memberId(test.getId())
+                .vehicleOptionId(testOption.getId())
+                .carNumber("12가3456")
+                .build());
+
+        driverRepository.save(Driver.builder()
+                .memberId(admin.getId())
+                .vehicleOptionId(adminOption.getId())
+                .carNumber("99나8765")
+                .build());
+    }
+
+    private List<VehicleOption> initVehicleOptions() {
+        if (vehicleOptionRepository.count() > 0) {
+            return vehicleOptionRepository.findAll();
+        }
 
         List<String[]> models = List.of(
                 new String[]{"현대", "아반떼"},
@@ -143,6 +169,6 @@ public class LocalDataInitializer implements CommandLineRunner {
                         .brand(m[0]).model(m[1]).color(color).build());
             }
         }
-        vehicleOptionRepository.saveAll(options);
+        return vehicleOptionRepository.saveAll(options);
     }
 }


### PR DESCRIPTION
## Summary
- DriverRepository.existsByCarNumber → existsByCarNumberAndDeletedFalse 변경 (soft-delete 버그 수정)
- ApplicationRepository에 findByPostIdAndStatus 메서드 추가
- RideService.createRide: 드라이버 등록 여부 검증, ACCEPTED 신청자를 RidePassenger로 자동 추가
- LocalDataInitializer: 앱 시작 시 test/admin 계정 드라이버 자동 등록 (mock 데이터)

## Test plan
- [ ] 드라이버 미등록 상태에서 POST /api/v1/drivers → 201 등록 성공
- [ ] 이미 등록된 상태에서 재등록 → 409 DRIVER_001
- [ ] soft-delete 후 동일 차량번호 재등록 → 중복 아님 (버그 수정 확인)
- [ ] 드라이버 미등록 상태에서 POST /api/v1/rides → 404 DRIVER_NOT_FOUND
- [ ] 앱 시작 후 GET /api/v1/drivers/me (test 계정) → 아반떼/12가3456 반환

Closes #51