### PR TITLE
feat: 차량번호 형식 유효성 검증 추가

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/driver/dto/DriverRegisterRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/driver/dto/DriverRegisterRequest.java
@@ -2,6 +2,7 @@ package com.techeer.carpool.domain.driver.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
@@ -11,5 +12,6 @@ public class DriverRegisterRequest {
     private Long vehicleOptionId;
 
     @NotBlank(message = "차량 번호를 입력해주세요.")
+    @Pattern(regexp = "^\\d{2,3}[가-힣]\\d{4}$", message = "차량 번호 형식이 올바르지 않습니다. (예: 12가3456, 123가4567)")
     private String carNumber;
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/driver/dto/DriverUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/driver/dto/DriverUpdateRequest.java
@@ -2,6 +2,7 @@ package com.techeer.carpool.domain.driver.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
@@ -11,5 +12,6 @@ public class DriverUpdateRequest {
     private Long vehicleOptionId;
 
     @NotBlank(message = "차량 번호를 입력해주세요.")
+    @Pattern(regexp = "^\\d{2,3}[가-힣]\\d{4}$", message = "차량 번호 형식이 올바르지 않습니다. (예: 12가3456, 123가4567)")
     private String carNumber;
 }


### PR DESCRIPTION
## Summary
- `DriverRegisterRequest`, `DriverUpdateRequest` `carNumber` 필드에 `@Pattern` 추가
- 정규식: `^\d{2,3}[가-힣]\d{4}$`
  - 구형 7자리: `12가3456`
  - 신형 8자리: `123가4567`
- 형식 불일치 시 400 `COMMON_001` 반환

## Test plan
- [ ] `12가3456` → 201 성공
- [ ] `123가4567` → 201 성공
- [ ] `abc`, `1234`, `!!가1234` → 400 COMMON_001

Closes #53