### PR TITLE
feat: 운행 라이프사이클, 평점 시스템, WebSocket 실시간 위치 공유 구현 (#55)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.techeer.carpool.domain.member.controller;
 import com.techeer.carpool.domain.member.dto.ProfileResponse;
 import com.techeer.carpool.domain.member.dto.ProfileUpdateRequest;
 import com.techeer.carpool.domain.member.service.MemberProfileService;
+import com.techeer.carpool.domain.member.service.MemberWithdrawService;
 import com.techeer.carpool.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberProfileService memberProfileService;
+    private final MemberWithdrawService memberWithdrawService;
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<ProfileResponse>> getProfileById(
@@ -40,5 +42,12 @@ public class MemberController {
         Long memberId = (Long) authentication.getPrincipal();
         ProfileResponse profile = memberProfileService.updateProfile(memberId, request);
         return ResponseEntity.ok(ApiResponse.of("프로필이 수정되었습니다.", profile));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> withdraw(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        memberWithdrawService.withdraw(memberId);
+        return ResponseEntity.ok(ApiResponse.of("회원 탈퇴가 완료되었습니다."));
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
@@ -3,10 +3,12 @@ package com.techeer.carpool.domain.post.controller;
 import com.techeer.carpool.domain.post.dto.PostCreateRequest;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.dto.PostUpdateRequest;
+import com.techeer.carpool.domain.post.service.PostCloseService;
 import com.techeer.carpool.domain.post.service.PostCreateService;
 import com.techeer.carpool.domain.post.service.PostDeleteService;
 import com.techeer.carpool.domain.post.service.PostReadService;
 import com.techeer.carpool.domain.post.service.PostUpdateService;
+import com.techeer.carpool.domain.ride.dto.RideResponse;
 import com.techeer.carpool.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class PostController {
     private final PostReadService postReadService;
     private final PostUpdateService postUpdateService;
     private final PostDeleteService postDeleteService;
+    private final PostCloseService postCloseService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<PostResponse>> createPost(
@@ -63,5 +66,13 @@ public class PostController {
         Long memberId = (Long) authentication.getPrincipal();
         postDeleteService.deletePost(id, memberId);
         return ResponseEntity.ok(ApiResponse.of("게시글이 삭제되었습니다."));
+    }
+
+    @PostMapping("/{id}/close")
+    public ResponseEntity<ApiResponse<RideResponse>> closePost(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("신청이 마감되었습니다. 운행이 예약되었습니다.", postCloseService.closePost(id, memberId)));
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -97,6 +97,13 @@ public class Post extends SoftDeletableEntity {
         this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
     }
 
+    public void close() {
+        if (this.status == PostStatus.CLOSED) {
+            throw new IllegalStateException("이미 마감된 게시글입니다.");
+        }
+        this.status = PostStatus.CLOSED;
+    }
+
     public boolean isFull() {
         return this.currentPassengers >= this.maxPassengers;
     }
@@ -127,7 +134,7 @@ public class Post extends SoftDeletableEntity {
         this.destinationLng = command.destinationLng();
         this.departureTime = command.departureTime();
         this.maxPassengers = command.maxPassengers();
-        this.description = command.description();
+        if (command.description() != null) this.description = command.description();
         this.autoAccept = command.autoAccept();
         this.status = command.status();
         this.price = command.price();

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCloseService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCloseService.java
@@ -1,0 +1,68 @@
+package com.techeer.carpool.domain.post.service;
+
+import com.techeer.carpool.domain.application.entity.Application;
+import com.techeer.carpool.domain.application.entity.ApplicationStatus;
+import com.techeer.carpool.domain.application.repository.ApplicationRepository;
+import com.techeer.carpool.domain.driver.repository.DriverRepository;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.entity.PostStatus;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.domain.ride.dto.RideResponse;
+import com.techeer.carpool.domain.ride.entity.Ride;
+import com.techeer.carpool.domain.ride.entity.RidePassenger;
+import com.techeer.carpool.domain.ride.repository.RidePassengerRepository;
+import com.techeer.carpool.domain.ride.repository.RideRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostCloseService {
+
+    private final PostRepository postRepository;
+    private final RideRepository rideRepository;
+    private final RidePassengerRepository ridePassengerRepository;
+    private final ApplicationRepository applicationRepository;
+    private final DriverRepository driverRepository;
+
+    @Transactional
+    public RideResponse closePost(Long postId, Long requesterId) {
+        driverRepository.findByMemberIdAndDeletedFalse(requesterId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.DRIVER_NOT_FOUND));
+
+        Post post = postRepository.findByIdAndDeletedFalse(postId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
+
+        if (!post.getMemberId().equals(requesterId)) {
+            throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
+        }
+        if (post.getStatus() == PostStatus.CLOSED) {
+            throw new CarpoolException(ErrorCode.POST_ALREADY_CLOSED);
+        }
+
+        post.close();
+
+        Ride ride = rideRepository.save(Ride.builder()
+                .postId(postId)
+                .driverId(requesterId)
+                .build());
+
+        List<Application> accepted = applicationRepository.findByPostIdAndStatus(postId, ApplicationStatus.ACCEPTED);
+        List<RidePassenger> passengers = accepted.stream()
+                .map(app -> RidePassenger.builder()
+                        .ride(ride)
+                        .applicationId(app.getId())
+                        .passengerId(app.getApplicantId())
+                        .build())
+                .collect(Collectors.toList());
+        ridePassengerRepository.saveAll(passengers);
+
+        return RideResponse.from(ride, post);
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/controller/ReviewController.java
@@ -1,0 +1,46 @@
+package com.techeer.carpool.domain.review.controller;
+
+import com.techeer.carpool.domain.review.dto.DriverRatingResponse;
+import com.techeer.carpool.domain.review.dto.ReviewCreateRequest;
+import com.techeer.carpool.domain.review.dto.ReviewResponse;
+import com.techeer.carpool.domain.review.service.ReviewService;
+import com.techeer.carpool.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReviewResponse>> createReview(
+            @RequestBody @Valid ReviewCreateRequest request,
+            Authentication authentication) {
+        Long reviewerId = (Long) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of("평가가 등록되었습니다.", reviewService.createReview(request, reviewerId)));
+    }
+
+    @GetMapping("/ride/{rideId}/me")
+    public ResponseEntity<ApiResponse<ReviewResponse>> getMyReview(
+            @PathVariable Long rideId,
+            Authentication authentication) {
+        Long reviewerId = (Long) authentication.getPrincipal();
+        Optional<ReviewResponse> review = reviewService.getMyReviewForRide(rideId, reviewerId);
+        return ResponseEntity.ok(ApiResponse.of("내 평가 조회 성공", review.orElse(null)));
+    }
+
+    @GetMapping("/driver/{driverId}/rating")
+    public ResponseEntity<ApiResponse<DriverRatingResponse>> getDriverRating(@PathVariable Long driverId) {
+        return ResponseEntity.ok(ApiResponse.of("드라이버 평점 조회 성공", reviewService.getDriverRating(driverId)));
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/review/dto/DriverRatingResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/dto/DriverRatingResponse.java
@@ -1,0 +1,21 @@
+package com.techeer.carpool.domain.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DriverRatingResponse {
+
+    private Long driverId;
+    private Double averageRating;
+    private long totalCount;
+
+    public static DriverRatingResponse of(Long driverId, Double avg, long count) {
+        return DriverRatingResponse.builder()
+                .driverId(driverId)
+                .averageRating(avg != null ? Math.round(avg * 10.0) / 10.0 : null)
+                .totalCount(count)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/review/dto/ReviewCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/dto/ReviewCreateRequest.java
@@ -1,0 +1,19 @@
+package com.techeer.carpool.domain.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ReviewCreateRequest {
+
+    @NotNull
+    private Long rideId;
+
+    @NotNull
+    @Min(1) @Max(5)
+    private Integer rating;
+
+    private String comment;
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/review/dto/ReviewResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/dto/ReviewResponse.java
@@ -1,0 +1,32 @@
+package com.techeer.carpool.domain.review.dto;
+
+import com.techeer.carpool.domain.review.entity.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReviewResponse {
+
+    private Long id;
+    private Long rideId;
+    private Long reviewerId;
+    private Long driverId;
+    private int rating;
+    private String comment;
+    private LocalDateTime createdAt;
+
+    public static ReviewResponse from(Review review) {
+        return ReviewResponse.builder()
+                .id(review.getId())
+                .rideId(review.getRideId())
+                .reviewerId(review.getReviewerId())
+                .driverId(review.getDriverId())
+                .rating(review.getRating())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/review/entity/Review.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/entity/Review.java
@@ -1,0 +1,34 @@
+package com.techeer.carpool.domain.review.entity;
+
+import com.techeer.carpool.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "reviews",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"ride_id", "reviewer_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ride_id", nullable = false)
+    private Long rideId;
+
+    @Column(name = "reviewer_id", nullable = false)
+    private Long reviewerId;
+
+    @Column(name = "driver_id", nullable = false)
+    private Long driverId;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(length = 500)
+    private String comment;
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,21 @@
+package com.techeer.carpool.domain.review.repository;
+
+import com.techeer.carpool.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Optional<Review> findByRideIdAndReviewerId(Long rideId, Long reviewerId);
+
+    boolean existsByRideIdAndReviewerId(Long rideId, Long reviewerId);
+
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.driverId = :driverId")
+    Double findAverageRatingByDriverId(@Param("driverId") Long driverId);
+
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.driverId = :driverId")
+    long countByDriverId(@Param("driverId") Long driverId);
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/service/ReviewService.java
@@ -1,0 +1,67 @@
+package com.techeer.carpool.domain.review.service;
+
+import com.techeer.carpool.domain.review.dto.DriverRatingResponse;
+import com.techeer.carpool.domain.review.dto.ReviewCreateRequest;
+import com.techeer.carpool.domain.review.dto.ReviewResponse;
+import com.techeer.carpool.domain.review.entity.Review;
+import com.techeer.carpool.domain.review.repository.ReviewRepository;
+import com.techeer.carpool.domain.ride.entity.Ride;
+import com.techeer.carpool.domain.ride.entity.RideStatus;
+import com.techeer.carpool.domain.ride.repository.RideRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final RideRepository rideRepository;
+
+    @Transactional
+    public ReviewResponse createReview(ReviewCreateRequest request, Long reviewerId) {
+        Ride ride = rideRepository.findById(request.getRideId())
+                .orElseThrow(() -> new CarpoolException(ErrorCode.RIDE_NOT_FOUND));
+
+        if (ride.getStatus() != RideStatus.COMPLETED) {
+            throw new CarpoolException(ErrorCode.REVIEW_RIDE_NOT_COMPLETED);
+        }
+
+        boolean isPassenger = ride.getPassengers().stream()
+                .anyMatch(p -> p.getPassengerId().equals(reviewerId));
+        if (!isPassenger) {
+            throw new CarpoolException(ErrorCode.REVIEW_FORBIDDEN);
+        }
+
+        if (reviewRepository.existsByRideIdAndReviewerId(request.getRideId(), reviewerId)) {
+            throw new CarpoolException(ErrorCode.REVIEW_ALREADY_EXISTS);
+        }
+
+        Review review = reviewRepository.save(Review.builder()
+                .rideId(request.getRideId())
+                .reviewerId(reviewerId)
+                .driverId(ride.getDriverId())
+                .rating(request.getRating())
+                .comment(request.getComment())
+                .build());
+
+        return ReviewResponse.from(review);
+    }
+
+    public Optional<ReviewResponse> getMyReviewForRide(Long rideId, Long reviewerId) {
+        return reviewRepository.findByRideIdAndReviewerId(rideId, reviewerId)
+                .map(ReviewResponse::from);
+    }
+
+    public DriverRatingResponse getDriverRating(Long driverId) {
+        Double avg = reviewRepository.findAverageRatingByDriverId(driverId);
+        long count = reviewRepository.countByDriverId(driverId);
+        return DriverRatingResponse.of(driverId, avg, count);
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/controller/RideController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/controller/RideController.java
@@ -28,6 +28,18 @@ public class RideController {
                 .body(ApiResponse.of("운행이 생성되었습니다.", rideService.createRide(request, driverId)));
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<RideResponse>>> getMyRidesAsDriver(Authentication authentication) {
+        Long driverId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("내 운행 목록 조회 성공", rideService.getMyRidesAsDriver(driverId)));
+    }
+
+    @GetMapping("/me/passenger")
+    public ResponseEntity<ApiResponse<List<RideResponse>>> getMyRidesAsPassenger(Authentication authentication) {
+        Long passengerId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.of("내 탑승 내역 조회 성공", rideService.getMyRidesAsPassenger(passengerId)));
+    }
+
     @GetMapping("/{rideId}")
     public ResponseEntity<ApiResponse<RideResponse>> getRide(@PathVariable Long rideId) {
         return ResponseEntity.ok(ApiResponse.of("운행 조회 성공", rideService.getRide(rideId)));

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/controller/RideWebSocketController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/controller/RideWebSocketController.java
@@ -1,0 +1,41 @@
+package com.techeer.carpool.domain.ride.controller;
+
+import com.techeer.carpool.domain.ride.dto.LocationBroadcast;
+import com.techeer.carpool.domain.ride.dto.LocationMessage;
+import com.techeer.carpool.domain.ride.service.RideService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+@Controller
+@RequiredArgsConstructor
+public class RideWebSocketController {
+
+    private final RideService rideService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/ride/{rideId}/location")
+    public void handleLocation(
+            @DestinationVariable Long rideId,
+            @Payload LocationMessage message,
+            Principal principal) {
+        if (principal == null) return;
+        Long driverId = Long.parseLong(principal.getName());
+
+        rideService.updateLocationDirect(rideId, message.getLatitude(), message.getLongitude(), driverId);
+
+        messagingTemplate.convertAndSend("/topic/ride/" + rideId,
+                LocationBroadcast.builder()
+                        .rideId(rideId)
+                        .latitude(message.getLatitude())
+                        .longitude(message.getLongitude())
+                        .timestamp(LocalDateTime.now().toString())
+                        .build());
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/dto/LocationBroadcast.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/dto/LocationBroadcast.java
@@ -1,0 +1,13 @@
+package com.techeer.carpool.domain.ride.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LocationBroadcast {
+    private Long rideId;
+    private Double latitude;
+    private Double longitude;
+    private String timestamp;
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/dto/LocationMessage.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/dto/LocationMessage.java
@@ -1,0 +1,11 @@
+package com.techeer.carpool.domain.ride.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LocationMessage {
+    private Double latitude;
+    private Double longitude;
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/dto/RideResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/dto/RideResponse.java
@@ -1,5 +1,6 @@
 package com.techeer.carpool.domain.ride.dto;
 
+import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.ride.entity.Ride;
 import com.techeer.carpool.domain.ride.entity.RideStatus;
 import lombok.Builder;
@@ -20,7 +21,19 @@ public class RideResponse {
     private LocalDateTime startedAt;
     private LocalDateTime completedAt;
 
+    private LocalDateTime departureTime;
+    private String departureLocation;
+    private Double departureLat;
+    private Double departureLng;
+    private String destinationLocation;
+    private Double destinationLat;
+    private Double destinationLng;
+
     public static RideResponse from(Ride ride) {
+        return from(ride, null);
+    }
+
+    public static RideResponse from(Ride ride, Post post) {
         return RideResponse.builder()
                 .id(ride.getId())
                 .postId(ride.getPostId())
@@ -30,6 +43,13 @@ public class RideResponse {
                 .currentLongitude(ride.getCurrentLongitude())
                 .startedAt(ride.getStartedAt())
                 .completedAt(ride.getCompletedAt())
+                .departureTime(post != null ? post.getDepartureTime() : null)
+                .departureLocation(post != null ? post.getDepartureLocation() : null)
+                .departureLat(post != null ? post.getDepartureLat() : null)
+                .departureLng(post != null ? post.getDepartureLng() : null)
+                .destinationLocation(post != null ? post.getDestinationLocation() : null)
+                .destinationLat(post != null ? post.getDestinationLat() : null)
+                .destinationLng(post != null ? post.getDestinationLng() : null)
                 .build();
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/entity/Ride.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/entity/Ride.java
@@ -66,13 +66,12 @@ public class Ride extends BaseEntity {
         this.completedAt = LocalDateTime.now();   // 종료 시각 기록
     }
 
-    // 드라이버 위치 업데이트 (브라우저 Geolocation API가 주기적으로 호출)
+    // 드라이버 위치 업데이트 (출발 30분 전(SCHEDULED) 또는 운행 중(IN_PROGRESS) 허용)
     public void updateLocation(Double latitude, Double longitude) {
-        // 운행 중일 때만 위치 업데이트 허용
-        if (this.status != RideStatus.IN_PROGRESS) {
-            throw new IllegalStateException("진행 중인 운행만 위치를 업데이트할 수 있습니다.");
+        if (this.status == RideStatus.COMPLETED) {
+            throw new IllegalStateException("완료된 운행은 위치를 업데이트할 수 없습니다.");
         }
-        this.currentLatitude = latitude;    // 위도 갱신
-        this.currentLongitude = longitude;  // 경도 갱신
+        this.currentLatitude = latitude;
+        this.currentLongitude = longitude;
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RidePassengerRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RidePassengerRepository.java
@@ -3,12 +3,12 @@ package com.techeer.carpool.domain.ride.repository;
 import com.techeer.carpool.domain.ride.entity.RidePassenger;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RidePassengerRepository extends JpaRepository<RidePassenger, Long> {
 
-    // Spring Data JPA의 메서드 이름 규칙으로 자동 쿼리 생성
-    // "findBy + 필드명 + And + 필드명" 형태로 작성하면 JPA가 알아서 SQL을 만들어줌
-    // → SELECT * FROM ride_passengers WHERE ride_id = ? AND application_id = ?
     Optional<RidePassenger> findByRideIdAndApplicationId(Long rideId, Long applicationId);
+
+    List<RidePassenger> findAllByPassengerIdOrderByCreatedAtDesc(Long passengerId);
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideRepository.java
@@ -3,8 +3,9 @@ package com.techeer.carpool.domain.ride.repository;
 import com.techeer.carpool.domain.ride.entity.Ride;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-// JpaRepository를 상속받으면 기본 CRUD 메서드가 자동으로 생성됨
-// <Ride, Long> → 엔티티 타입이 Ride이고, PK 타입이 Long
-// 별도로 메서드를 추가하지 않아도 save(), findById(), findAll(), deleteById() 등 기본 제공
+import java.util.List;
+
 public interface RideRepository extends JpaRepository<Ride, Long> {
+
+    List<Ride> findAllByDriverIdOrderByCreatedAtDesc(Long driverId);
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -43,7 +43,7 @@ public class RideService {
         if (!post.getMemberId().equals(driverId)) {
             throw new CarpoolException(ErrorCode.RIDE_FORBIDDEN);
         }
-        if (post.getStatus() != PostStatus.OPEN) {
+        if (post.getStatus() != PostStatus.OPEN && post.getStatus() != PostStatus.CLOSED) {
             throw new CarpoolException(ErrorCode.RIDE_INVALID_STATUS);
         }
         Ride ride = rideRepository.save(Ride.builder()
@@ -62,11 +62,13 @@ public class RideService {
                 .collect(Collectors.toList());
         ridePassengerRepository.saveAll(passengers);
 
-        return RideResponse.from(ride);
+        return RideResponse.from(ride, post);
     }
 
     public RideResponse getRide(Long rideId) {
-        return RideResponse.from(findRideById(rideId));
+        Ride ride = findRideById(rideId);
+        Post post = postRepository.findByIdAndDeletedFalse(ride.getPostId()).orElse(null);
+        return RideResponse.from(ride, post);
     }
 
     @Transactional
@@ -74,7 +76,8 @@ public class RideService {
         Ride ride = findRideById(rideId);
         validateDriver(ride, requesterId);
         ride.start();
-        return RideResponse.from(ride);
+        Post post = postRepository.findByIdAndDeletedFalse(ride.getPostId()).orElse(null);
+        return RideResponse.from(ride, post);
     }
 
     @Transactional
@@ -82,7 +85,8 @@ public class RideService {
         Ride ride = findRideById(rideId);
         validateDriver(ride, requesterId);
         ride.complete();
-        return RideResponse.from(ride);
+        Post post = postRepository.findByIdAndDeletedFalse(ride.getPostId()).orElse(null);
+        return RideResponse.from(ride, post);
     }
 
     @Transactional
@@ -93,8 +97,37 @@ public class RideService {
         return LocationResponse.from(ride);
     }
 
+    @Transactional
+    public void updateLocationDirect(Long rideId, Double latitude, Double longitude, Long requesterId) {
+        Ride ride = rideRepository.findById(rideId).orElse(null);
+        if (ride == null || !ride.getDriverId().equals(requesterId)) return;
+        if (ride.getStatus() == RideStatus.COMPLETED) return;
+        ride.updateLocation(latitude, longitude);
+    }
+
     public LocationResponse getLocation(Long rideId) {
         return LocationResponse.from(findRideById(rideId));
+    }
+
+    public List<RideResponse> getMyRidesAsDriver(Long driverId) {
+        return rideRepository.findAllByDriverIdOrderByCreatedAtDesc(driverId)
+                .stream()
+                .map(ride -> {
+                    Post post = postRepository.findByIdAndDeletedFalse(ride.getPostId()).orElse(null);
+                    return RideResponse.from(ride, post);
+                })
+                .collect(Collectors.toList());
+    }
+
+    public List<RideResponse> getMyRidesAsPassenger(Long passengerId) {
+        return ridePassengerRepository.findAllByPassengerIdOrderByCreatedAtDesc(passengerId)
+                .stream()
+                .map(rp -> {
+                    Ride ride = rp.getRide();
+                    Post post = postRepository.findByIdAndDeletedFalse(ride.getPostId()).orElse(null);
+                    return RideResponse.from(ride, post);
+                })
+                .collect(Collectors.toList());
     }
 
     public List<PassengerResponse> getPassengers(Long rideId) {
@@ -126,6 +159,12 @@ public class RideService {
         RidePassenger passenger = findPassenger(rideId, applicationId);
         passenger.dropOff();
         return PassengerResponse.from(passenger);
+    }
+
+    public boolean isPassengerInRide(Long rideId, Long passengerId) {
+        Ride ride = findRideById(rideId);
+        return ride.getPassengers().stream()
+                .anyMatch(p -> p.getPassengerId().equals(passengerId));
     }
 
     private Ride findRideById(Long rideId) {

--- a/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/vehicles/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex

--- a/backend/src/main/java/com/techeer/carpool/global/config/WebSocketAuthChannelInterceptor.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/WebSocketAuthChannelInterceptor.java
@@ -1,0 +1,34 @@
+package com.techeer.carpool.global.config;
+
+import com.techeer.carpool.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String authHeader = accessor.getFirstNativeHeader("Authorization");
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                String token = authHeader.substring(7);
+                if (jwtTokenProvider.validateToken(token)) {
+                    Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
+                    accessor.setUser(() -> String.valueOf(memberId));
+                }
+            }
+        }
+        return message;
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/WebSocketConfig.java
@@ -1,0 +1,33 @@
+package com.techeer.carpool.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketAuthChannelInterceptor authInterceptor;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(authInterceptor);
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -34,7 +34,14 @@ public enum ErrorCode {
     RIDE_INVALID_STATUS("RIDE_003", "현재 상태에서 허용되지 않는 작업입니다.", HttpStatus.CONFLICT),
     RIDE_PASSENGER_NOT_FOUND("RIDE_004", "탑승자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
-    MEMBER_FORBIDDEN("MEMBER_001", "본인의 프로필만 조회할 수 있습니다.", HttpStatus.FORBIDDEN);
+    MEMBER_FORBIDDEN("MEMBER_001", "본인의 프로필만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
+
+    POST_ALREADY_CLOSED("POST_003", "이미 마감된 게시글입니다.", HttpStatus.CONFLICT),
+
+    REVIEW_ALREADY_EXISTS("REVIEW_001", "이미 평가한 운행입니다.", HttpStatus.CONFLICT),
+    REVIEW_FORBIDDEN("REVIEW_002", "평가 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    REVIEW_NOT_FOUND("REVIEW_003", "평가를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    REVIEW_RIDE_NOT_COMPLETED("REVIEW_004", "완료된 운행만 평가할 수 있습니다.", HttpStatus.CONFLICT);
 
 
     private final String code;

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -1,18 +1,27 @@
 package com.techeer.carpool.global.init;
 
+import com.techeer.carpool.domain.application.entity.Application;
+import com.techeer.carpool.domain.application.repository.ApplicationRepository;
 import com.techeer.carpool.domain.comment.entity.Comment;
 import com.techeer.carpool.domain.comment.repository.CommentRepository;
 import com.techeer.carpool.domain.driver.entity.Driver;
 import com.techeer.carpool.domain.driver.repository.DriverRepository;
 import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
-
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.entity.PostStatus;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.domain.review.entity.Review;
+import com.techeer.carpool.domain.review.repository.ReviewRepository;
+import com.techeer.carpool.domain.ride.entity.Ride;
+import com.techeer.carpool.domain.ride.entity.RidePassenger;
+import com.techeer.carpool.domain.ride.entity.RideStatus;
+import com.techeer.carpool.domain.ride.entity.PassengerStatus;
+import com.techeer.carpool.domain.ride.repository.RidePassengerRepository;
+import com.techeer.carpool.domain.ride.repository.RideRepository;
 import com.techeer.carpool.domain.vehicle.entity.CarColor;
 import com.techeer.carpool.domain.vehicle.entity.VehicleOption;
 import com.techeer.carpool.domain.vehicle.repository.VehicleOptionRepository;
-
-import com.techeer.carpool.domain.post.entity.Post;
-import com.techeer.carpool.domain.post.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +42,10 @@ public class LocalDataInitializer implements CommandLineRunner {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final ApplicationRepository applicationRepository;
+    private final RideRepository rideRepository;
+    private final RidePassengerRepository ridePassengerRepository;
+    private final ReviewRepository reviewRepository;
     private final PasswordEncoder passwordEncoder;
     private final VehicleOptionRepository vehicleOptionRepository;
     private final DriverRepository driverRepository;
@@ -42,16 +55,25 @@ public class LocalDataInitializer implements CommandLineRunner {
         Member test  = createMemberIfNotExists("test@carpool.com",  "password1234", "테스트유저");
         Member admin = createMemberIfNotExists("admin@carpool.com", "admin1234!",   "관리자");
 
-        if (postRepository.findByDeletedFalseOrderByCreatedAtDesc().isEmpty()) {
-            seedPosts(test, admin);
+        seedDrivers(test, admin, initVehicleOptions());
+
+        List<Post> allPosts = postRepository.findByDeletedFalseOrderByCreatedAtDesc();
+        if (allPosts.isEmpty()) {
+            allPosts = seedPosts(test, admin);
         }
 
-        List<VehicleOption> vehicleOptions = initVehicleOptions();
-        seedDrivers(test, admin, vehicleOptions);
+        if (rideRepository.count() == 0) {
+            seedRides(test, admin, allPosts);
+        }
+
         log.info("[LocalDataInitializer] 초기 데이터 생성 완료");
     }
 
-    private void seedPosts(Member test, Member admin) {
+    // ── Posts ──────────────────────────────────────────────────────────────────
+
+    private List<Post> seedPosts(Member test, Member admin) {
+
+        // ① OPEN — 신청 모집 중 (admin 드라이버)
         Post p1 = postRepository.save(Post.builder()
                 .memberId(admin.getId())
                 .title("강남역 → 판교역")
@@ -64,8 +86,10 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .description("정시 출발합니다. 짐 많으신 분은 미리 말씀해 주세요.")
                 .autoAccept(false)
                 .price(5000)
+                .tags(List.of("NON_SMOKER", "QUIET"))
                 .build());
 
+        // ② OPEN — 신청 모집 중 (test 드라이버)
         Post p2 = postRepository.save(Post.builder()
                 .memberId(test.getId())
                 .title("홍대입구 → 여의도역")
@@ -78,44 +102,201 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .description("경유지 없이 직행입니다.")
                 .autoAccept(true)
                 .price(3000)
+                .tags(List.of("PET_OK", "LUGGAGE_OK"))
                 .build());
 
+        // ③ CLOSED → SCHEDULED 운행 (약 20분 후 출발 — 30분 전 위치 공유 테스트용, test 드라이버)
         Post p3 = postRepository.save(Post.builder()
-                .memberId(admin.getId())
+                .memberId(test.getId())
                 .title("서울역 → 수원역")
                 .departureLocation("서울역")
                 .departureLat(37.5547).departureLng(126.9707)
                 .destinationLocation("수원역")
                 .destinationLat(37.2664).destinationLng(127.0003)
-                .departureTime(LocalDateTime.now().plusDays(3).withHour(7).withMinute(0).withSecond(0).withNano(0))
+                .departureTime(LocalDateTime.now().plusMinutes(20))
                 .maxPassengers(4)
-                .description("반드시 제시간에 탑승 부탁드립니다.")
+                .description("출발 20분 전 — 위치 공유 창 테스트용입니다.")
                 .autoAccept(false)
                 .price(4000)
+                .tags(List.of("NON_SMOKER"))
+                .build());
+
+        // ④ CLOSED → IN_PROGRESS 운행 중 (admin 드라이버, test 탑승 중)
+        Post p4 = postRepository.save(Post.builder()
+                .memberId(admin.getId())
+                .title("잠실역 → 강남역")
+                .departureLocation("잠실역")
+                .departureLat(37.5133).departureLng(127.1001)
+                .destinationLocation("강남역")
+                .destinationLat(37.4979).destinationLng(127.0276)
+                .departureTime(LocalDateTime.now().minusMinutes(25))
+                .maxPassengers(3)
+                .description("현재 운행 중 — ActiveRidePanel 테스트용")
+                .autoAccept(true)
+                .price(3500)
+                .tags(List.of("QUIET"))
+                .build());
+
+        // ⑤ CLOSED → COMPLETED (test 드라이버, admin 탑승 완료 + 평점 등록됨)
+        Post p5 = postRepository.save(Post.builder()
+                .memberId(test.getId())
+                .title("삼성역 → 잠실역")
+                .departureLocation("삼성역")
+                .departureLat(37.5087).departureLng(127.0632)
+                .destinationLocation("잠실역")
+                .destinationLat(37.5133).destinationLng(127.1001)
+                .departureTime(LocalDateTime.now().minusDays(3).withHour(9).withMinute(0).withSecond(0).withNano(0))
+                .maxPassengers(2)
+                .description("과거 완료 운행 — 평점 등록 완료 케이스")
+                .autoAccept(false)
+                .price(2000)
+                .build());
+
+        // ⑥ CLOSED → COMPLETED (admin 드라이버, test 탑승 완료 + 평점 미등록)
+        Post p6 = postRepository.save(Post.builder()
+                .memberId(admin.getId())
+                .title("신촌역 → 인천공항 T1")
+                .departureLocation("신촌역")
+                .departureLat(37.5551).departureLng(126.9368)
+                .destinationLocation("인천공항 T1")
+                .destinationLat(37.4491).destinationLng(126.4506)
+                .departureTime(LocalDateTime.now().minusDays(1).withHour(5).withMinute(30).withSecond(0).withNano(0))
+                .maxPassengers(3)
+                .description("과거 완료 운행 — 평점 미등록 케이스 (★ 평가하기 버튼 표시)")
+                .autoAccept(true)
+                .price(15000)
+                .tags(List.of("LUGGAGE_OK"))
                 .build());
 
         seedComments(p1, test, admin);
         seedComments(p2, admin, test);
-        seedComments(p3, test, admin);
+
+        return List.of(p1, p2, p3, p4, p5, p6);
     }
 
     private void seedComments(Post post, Member first, Member second) {
         commentRepository.save(Comment.builder()
-                .postId(post.getId())
-                .memberId(first.getId())
-                .content("저도 같은 방향이에요! 탑승 가능할까요?")
-                .build());
+                .postId(post.getId()).memberId(first.getId())
+                .content("저도 같은 방향이에요! 탑승 가능할까요?").build());
         commentRepository.save(Comment.builder()
-                .postId(post.getId())
-                .memberId(second.getId())
-                .content("몇 시쯤 도착 예정인가요?")
-                .build());
+                .postId(post.getId()).memberId(second.getId())
+                .content("몇 시쯤 도착 예정인가요?").build());
         commentRepository.save(Comment.builder()
-                .postId(post.getId())
-                .memberId(first.getId())
-                .content("좋아요, 당일 아침에 다시 연락 드릴게요 :)")
-                .build());
+                .postId(post.getId()).memberId(first.getId())
+                .content("좋아요, 당일 아침에 다시 연락 드릴게요 :)").build());
     }
+
+    // ── Rides ──────────────────────────────────────────────────────────────────
+
+    private void seedRides(Member test, Member admin, List<Post> posts) {
+        Post p3 = findByTitle(posts, "서울역 → 수원역");      // test 드라이버, 20분 후 출발
+        Post p4 = findByTitle(posts, "잠실역 → 강남역");      // admin 드라이버, 운행 중
+        Post p5 = findByTitle(posts, "삼성역 → 잠실역");      // test 드라이버, 완료+평점 있음
+        Post p6 = findByTitle(posts, "신촌역 → 인천공항 T1"); // admin 드라이버, 완료+평점 없음
+
+        if (p3 == null || p4 == null || p5 == null || p6 == null) return;
+
+        // ─── SCHEDULED (출발 20분 전) ───
+        // test가 드라이버, admin이 탑승 예정 → SCHEDULED → 위치 공유 창 표시
+        closePost(p3);
+        Application appA = saveAcceptedApplication(p3.getId(), admin.getId());
+        Ride ride1 = rideRepository.save(Ride.builder()
+                .postId(p3.getId())
+                .driverId(test.getId())
+                .build()); // status 기본값 SCHEDULED
+        ridePassengerRepository.save(RidePassenger.builder()
+                .ride(ride1)
+                .applicationId(appA.getId())
+                .passengerId(admin.getId())
+                .build()); // status 기본값 PENDING
+
+        // ─── IN_PROGRESS (운행 중) ───
+        // admin이 드라이버, test가 탑승 중 → ActiveRidePanel (승객) 표시
+        closePost(p4);
+        Application appB = saveAcceptedApplication(p4.getId(), test.getId());
+        Ride ride2 = rideRepository.save(Ride.builder()
+                .postId(p4.getId())
+                .driverId(admin.getId())
+                .status(RideStatus.IN_PROGRESS)
+                .currentLatitude(37.5133)
+                .currentLongitude(127.0700)
+                .startedAt(LocalDateTime.now().minusMinutes(20))
+                .build());
+        ridePassengerRepository.save(RidePassenger.builder()
+                .ride(ride2)
+                .applicationId(appB.getId())
+                .passengerId(test.getId())
+                .status(PassengerStatus.BOARDED)
+                .boardedAt(LocalDateTime.now().minusMinutes(18))
+                .build());
+
+        // ─── COMPLETED + 평점 등록 완료 ───
+        // test가 드라이버, admin이 탑승 완료 + 이미 평점 남김
+        closePost(p5);
+        Application appC = saveAcceptedApplication(p5.getId(), admin.getId());
+        Ride ride3 = rideRepository.save(Ride.builder()
+                .postId(p5.getId())
+                .driverId(test.getId())
+                .status(RideStatus.COMPLETED)
+                .startedAt(LocalDateTime.now().minusDays(3).withHour(9).withMinute(0))
+                .completedAt(LocalDateTime.now().minusDays(3).withHour(9).withMinute(45))
+                .build());
+        ridePassengerRepository.save(RidePassenger.builder()
+                .ride(ride3)
+                .applicationId(appC.getId())
+                .passengerId(admin.getId())
+                .status(PassengerStatus.DROPPED_OFF)
+                .boardedAt(LocalDateTime.now().minusDays(3).withHour(9).withMinute(3))
+                .droppedOffAt(LocalDateTime.now().minusDays(3).withHour(9).withMinute(45))
+                .build());
+        // admin이 test 드라이버에게 평점 등록 (★★★★★ — ReviewModal "평가 완료" 표시 확인)
+        reviewRepository.save(Review.builder()
+                .rideId(ride3.getId())
+                .reviewerId(admin.getId())
+                .driverId(test.getId())
+                .rating(5)
+                .comment("운전이 안전하고 친절했어요! 다음에도 이용하고 싶습니다.")
+                .build());
+
+        // ─── COMPLETED + 평점 미등록 ───
+        // admin이 드라이버, test가 탑승 완료 + 평점 안 남김 → "★ 평가하기" 버튼 표시
+        closePost(p6);
+        Application appD = saveAcceptedApplication(p6.getId(), test.getId());
+        Ride ride4 = rideRepository.save(Ride.builder()
+                .postId(p6.getId())
+                .driverId(admin.getId())
+                .status(RideStatus.COMPLETED)
+                .startedAt(LocalDateTime.now().minusDays(1).withHour(5).withMinute(30))
+                .completedAt(LocalDateTime.now().minusDays(1).withHour(6).withMinute(50))
+                .build());
+        ridePassengerRepository.save(RidePassenger.builder()
+                .ride(ride4)
+                .applicationId(appD.getId())
+                .passengerId(test.getId())
+                .status(PassengerStatus.DROPPED_OFF)
+                .boardedAt(LocalDateTime.now().minusDays(1).withHour(5).withMinute(33))
+                .droppedOffAt(LocalDateTime.now().minusDays(1).withHour(6).withMinute(50))
+                .build());
+        // 평점 미등록 — test 로그인 시 "★ 드라이버 평가하기" 버튼이 ride4에 표시됨
+    }
+
+    private void closePost(Post post) {
+        try { post.close(); postRepository.save(post); }
+        catch (Exception ignored) {} // 이미 마감된 경우 무시
+    }
+
+    private Application saveAcceptedApplication(Long postId, Long applicantId) {
+        Application app = applicationRepository.save(
+                Application.builder().postId(postId).applicantId(applicantId).build());
+        app.accept();
+        return applicationRepository.save(app);
+    }
+
+    private Post findByTitle(List<Post> posts, String title) {
+        return posts.stream().filter(p -> title.equals(p.getTitle())).findFirst().orElse(null);
+    }
+
+    // ── Members ────────────────────────────────────────────────────────────────
 
     private Member createMemberIfNotExists(String email, String password, String nickname) {
         return memberRepository.findByEmail(email).orElseGet(() ->
@@ -126,30 +307,28 @@ public class LocalDataInitializer implements CommandLineRunner {
                         .build()));
     }
 
+    // ── Drivers ────────────────────────────────────────────────────────────────
+
     private void seedDrivers(Member test, Member admin, List<VehicleOption> vehicleOptions) {
         if (driverRepository.count() > 0) return;
 
-        // 아반떼 흰색(index 0), 소나타 검정(index 8)
-        VehicleOption testOption  = vehicleOptions.get(0);
-        VehicleOption adminOption = vehicleOptions.get(8);
-
         driverRepository.save(Driver.builder()
                 .memberId(test.getId())
-                .vehicleOptionId(testOption.getId())
+                .vehicleOptionId(vehicleOptions.get(0).getId())
                 .carNumber("12가3456")
                 .build());
 
         driverRepository.save(Driver.builder()
                 .memberId(admin.getId())
-                .vehicleOptionId(adminOption.getId())
+                .vehicleOptionId(vehicleOptions.get(8).getId())
                 .carNumber("99나8765")
                 .build());
     }
 
+    // ── Vehicle Options ────────────────────────────────────────────────────────
+
     private List<VehicleOption> initVehicleOptions() {
-        if (vehicleOptionRepository.count() > 0) {
-            return vehicleOptionRepository.findAll();
-        }
+        if (vehicleOptionRepository.count() > 0) return vehicleOptionRepository.findAll();
 
         List<String[]> models = List.of(
                 new String[]{"현대", "아반떼"},


### PR DESCRIPTION
## 관련 이슈
Closes #55

## 변경 사항

### 1. 신청 마감 / 운행 예약 자동 생성
- `POST /api/v1/posts/{id}/close` — 게시글 CLOSED 처리 + SCHEDULED Ride 자동 생성
- `PostCloseService`: ACCEPTED 신청자를 RidePassenger로 일괄 등록

### 2. 운행 상태 조회 API
- `GET /api/v1/rides/me` — 드라이버 본인 운행 목록
- `GET /api/v1/rides/me/passenger` — 탑승자 본인 탑승 내역
- `RideRepository.findAllByDriverIdOrderByCreatedAtDesc` 추가
- `RidePassengerRepository.findAllByPassengerIdOrderByCreatedAtDesc` 추가
- `RideResponse`에 출발지/목적지/좌표/시간 필드 추가 (프론트 추가 API 호출 불필요)

### 3. 평점 시스템
- `Review` 엔티티 신규 (rideId, reviewerId, driverId, rating, comment, unique 제약)
- `POST /api/v1/reviews` — COMPLETED 운행 탑승자만 등록 가능, 중복 방지
- `GET /api/v1/reviews/ride/{rideId}/me` — 내 평가 여부 조회
- `GET /api/v1/reviews/driver/{driverId}/rating` — 드라이버 평균 평점 조회

### 4. WebSocket 실시간 위치 공유
- `spring-boot-starter-websocket` 의존성 추가
- STOMP endpoint `/ws`, message prefix `/app`, broker prefix `/topic`
- `POST /app/ride/{id}/location` → `/topic/ride/{id}` 실시간 브로드캐스트
- JWT 기반 WebSocket 인증 채널 인터셉터
- SecurityConfig에 `/ws/**` 허용

### 5. 회원 탈퇴
- `DELETE /api/v1/members/me`

### 6. 에러코드 추가
- `POST_ALREADY_CLOSED`, `REVIEW_ALREADY_EXISTS`, `REVIEW_FORBIDDEN`, `REVIEW_NOT_FOUND`, `REVIEW_RIDE_NOT_COMPLETED`

### 7. 시드 데이터
- SCHEDULED(30분 내 출발) / IN_PROGRESS / COMPLETED(평점 있음) / COMPLETED(평점 없음) 4가지 운행 시나리오

## 운행 상태 흐름
```
OPEN → (신청마감) → CLOSED + Ride[SCHEDULED]
     → (운행시작) → IN_PROGRESS
     → (운행종료) → COMPLETED → 평점 등록 가능
```

## 테스트 계정
- `test@carpool.com` / `password1234` (memberId=1, 드라이버)
- `admin@carpool.com` / `admin1234!` (memberId=2, 드라이버)