### PR TITLE
fix: 시드 데이터 시간 민감 항목 동적 갱신 (#61)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -124,6 +124,10 @@ public class Post extends SoftDeletableEntity {
         }
     }
 
+    public void refreshDepartureTime(LocalDateTime time) {
+        this.departureTime = time;
+    }
+
     public void updateFrom(PostUpdateCommand command) {
         this.title = command.title();
         this.departureLocation = command.departureLocation();

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/entity/Ride.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/entity/Ride.java
@@ -46,6 +46,10 @@ public class Ride extends BaseEntity {
 
     // ── 비즈니스 로직 ──────────────────────────────────────
 
+    public void refreshStartedAt(LocalDateTime time) {
+        this.startedAt = time;
+    }
+
     // 운행 시작 처리
     public void start() {
         // 예정 상태가 아니면 시작 불가 (예: 이미 진행 중이거나 완료된 운행)

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/entity/RidePassenger.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/entity/RidePassenger.java
@@ -39,6 +39,10 @@ public class RidePassenger extends BaseEntity {
 
     // ── 비즈니스 로직 ──────────────────────────────────────
 
+    public void refreshBoardedAt(LocalDateTime time) {
+        this.boardedAt = time;
+    }
+
     // 탑승 확인 처리 (드라이버가 탑승자를 태웠을 때 호출)
     public void board() {
         // 대기 상태인 탑승자만 탑승 확인 가능

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RidePassengerRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RidePassengerRepository.java
@@ -10,5 +10,7 @@ public interface RidePassengerRepository extends JpaRepository<RidePassenger, Lo
 
     Optional<RidePassenger> findByRideIdAndApplicationId(Long rideId, Long applicationId);
 
+    List<RidePassenger> findByRideId(Long rideId);
+
     List<RidePassenger> findAllByPassengerIdOrderByCreatedAtDesc(Long passengerId);
 }

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -66,6 +66,8 @@ public class LocalDataInitializer implements CommandLineRunner {
             seedRides(test, admin, allPosts);
         }
 
+        refreshTimeSensitiveData(allPosts);
+
         log.info("[LocalDataInitializer] 초기 데이터 생성 완료");
     }
 
@@ -241,6 +243,33 @@ public class LocalDataInitializer implements CommandLineRunner {
         commentRepository.save(Comment.builder()
                 .postId(post.getId()).memberId(first.getId())
                 .content("좋아요, 당일 아침에 다시 연락 드릴게요 :)").build());
+    }
+
+    // ── Refresh ────────────────────────────────────────────────────────────────
+
+    private void refreshTimeSensitiveData(List<Post> posts) {
+        // 서울역 → 수원역: 앱 재시작 시마다 출발 시각을 지금으로부터 20분 후로 갱신
+        posts.stream()
+                .filter(p -> "서울역 → 수원역".equals(p.getTitle()))
+                .findFirst()
+                .ifPresent(p -> {
+                    p.refreshDepartureTime(LocalDateTime.now().plusMinutes(20));
+                    postRepository.save(p);
+                });
+
+        // IN_PROGRESS 운행: startedAt·boardedAt을 지금 기준으로 갱신
+        rideRepository.findAll().stream()
+                .filter(r -> r.getStatus() == RideStatus.IN_PROGRESS)
+                .findFirst()
+                .ifPresent(r -> {
+                    r.refreshStartedAt(LocalDateTime.now().minusMinutes(20));
+                    rideRepository.save(r);
+                    ridePassengerRepository.findByRideId(r.getId())
+                            .forEach(rp -> {
+                                rp.refreshBoardedAt(LocalDateTime.now().minusMinutes(18));
+                                ridePassengerRepository.save(rp);
+                            });
+                });
     }
 
     // ── Rides ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- 앱 재시작 시 `서울역 → 수원역` 게시글 출발 시각을 `now + 20분`으로 갱신
- `IN_PROGRESS` 운행의 `startedAt`/`boardedAt`을 현재 시각 기준으로 갱신
- `Post`, `Ride`, `RidePassenger`에 시각 갱신 전용 메서드 추가
- `RidePassengerRepository`에 `findByRideId` 추가

Closes #61

## Test plan

- [ ] 앱 최초 실행 → `서울역 → 수원역` departureTime이 `now + 20분`인지 확인
- [ ] 앱 재시작 → 동일 값이 현재 시각 기준으로 갱신되는지 확인
- [ ] IN_PROGRESS 운행 startedAt이 재시작 후 `now - 20분`으로 갱신되는지 확인