### PR TITLE
[Feat]컨테이너 및 쿠버네티스 트래픽 처리 설정 추가

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM eclipse-temurin:17-jdk AS builder
+WORKDIR /app
+COPY . .
+RUN ./gradlew bootJar -x test
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/src/main/java/com/techeer/carpool/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/RedisConfig.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 public class RedisConfig {
@@ -38,5 +39,11 @@ public class RedisConfig {
                 new PatternTopic("notification:*")
         );
         return container;
+    }
+
+    // JSON 직렬화/역직렬화
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,20 @@ services:
     container_name: carpool-redis
     ports:
       - "6379:6379"
+
+  app:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: carpool-app
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+      - redis
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/carpool
+      SPRING_DATASOURCE_USERNAME: user
+      SPRING_DATASOURCE_PASSWORD: password
+      REDIS_HOST: redis
+      SPRING_REDIS_PORT: 6379

--- a/k8s/db.yml
+++ b/k8s/db.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: carpool-db
+spec:
+  selector:
+    app: carpool-db
+  ports:
+    - port: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: carpool-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: carpool-db
+  template:
+    metadata:
+      labels:
+        app: carpool-db
+    spec:
+      containers:
+        - name: carpool-db
+          image: postgres:15
+          env:
+            - name: POSTGRES_USER
+              value: user
+            - name: POSTGRES_PASSWORD
+              value: password
+            - name: POSTGRES_DB
+              value: carpool
+          ports:
+            - containerPort: 5432

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: carpool-app
+spec:
+  replicas: 2          # 앱 컨테이너를 2개 띄움 (하나 죽어도 하나 살아있음)
+  selector:
+    matchLabels:
+      app: carpool-app
+  template:
+    metadata:
+      labels:
+        app: carpool-app
+    spec:
+      containers:
+      - name: carpool-app
+        image: carpool-app:latest        # Docker 이미지
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 8080
+        env:
+        - name: REDIS_HOST
+          value: carpool-redis
+        - name: SPRING_DATASOURCE_URL
+          value: jdbc:postgresql://carpool-db:5432/carpool
+        - name: SPRING_DATASOURCE_USERNAME
+          value: user
+        - name: SPRING_DATASOURCE_PASSWORD
+          value: password

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: carpool-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: carpool-app-service
+                port:
+                  number: 80

--- a/k8s/redis.yml
+++ b/k8s/redis.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: carpool-redis
+spec:
+  selector:
+    app: carpool-redis
+  ports:
+    - port: 6379
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: carpool-redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: carpool-redis
+  template:
+    metadata:
+      labels:
+        app: carpool-redis
+    spec:
+      containers:
+        - name: carpool-redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379

--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: carpool-app-service
+spec:
+  selector:
+    app: carpool-app
+  ports:
+    - port: 80
+      targetPort: 8080
+  type: NodePort


### PR DESCRIPTION
### Docker
- Spring Boot 앱 Dockerfile 추가
- docker-compose.yml에 app 서비스 추가 (db, redis 연동)

### Kubernetes
- deployment.yml: 앱 Pod 2개 배포 설정
- service.yml: 외부 트래픽을 Pod로 연결
- ingress.yml: HTTP 요청 라우팅 설정
- db.yml: PostgreSQL 쿠버네티스 배포
- redis.yml: Redis 쿠버네티스 배포

### Bug Fix
- RedisConfig에 ObjectMapper 빈 등록 누락 수정

## 테스트
- minikube로 로컬 쿠버네티스 실행 확인
- API 테스트 완료 (회원가입, 로그인)

closes #68 