### PR TITLE
feat: 알림 DB 영속화 (Notification 엔티티 추가)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/notification/entity/Notification.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/notification/entity/Notification.java
@@ -1,0 +1,118 @@
+package com.techeer.carpool.domain.notification.entity;
+
+import com.techeer.carpool.domain.notification.type.NotificationType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "notifications", indexes = {
+        @Index(name = "idx_notification_receiver_id", columnList = "receiver_id"),
+        @Index(name = "idx_notification_receiver_read", columnList = "receiver_id, read_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long notificationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private Long receiverId;
+
+    private Long referenceId;
+
+    @Column(nullable = false, length = 100)
+    private String message;
+
+    private LocalDateTime readAt;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    private Notification(NotificationType type, Long receiverId, Long referenceId, String message) {
+        Objects.requireNonNull(type, "type must not be null");
+        Objects.requireNonNull(receiverId, "receiverId must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        this.type = type;
+        this.receiverId = receiverId;
+        this.referenceId = referenceId;
+        this.message = message;
+    }
+
+    public static Notification ofApplicationReceived(Long receiverId, Long postId) {
+        return Notification.builder()
+                .type(NotificationType.APPLICATION_RECEIVED)
+                .receiverId(receiverId)
+                .referenceId(postId)
+                .message("카풀 신청이 도착했습니다.")
+                .build();
+    }
+
+    public static Notification ofApplicationAccepted(Long receiverId, Long postId) {
+        return Notification.builder()
+                .type(NotificationType.APPLICATION_ACCEPTED)
+                .receiverId(receiverId)
+                .referenceId(postId)
+                .message("카풀 신청이 승인되었습니다.")
+                .build();
+    }
+
+    public static Notification ofApplicationRejected(Long receiverId, Long postId) {
+        return Notification.builder()
+                .type(NotificationType.APPLICATION_REJECTED)
+                .receiverId(receiverId)
+                .referenceId(postId)
+                .message("카풀 신청이 거절되었습니다.")
+                .build();
+    }
+
+    public static Notification ofRideStarted(Long receiverId, Long rideId) {
+        return Notification.builder()
+                .type(NotificationType.RIDE_STARTED)
+                .receiverId(receiverId)
+                .referenceId(rideId)
+                .message("카풀 운행이 시작되었습니다.")
+                .build();
+    }
+
+    public static Notification ofRideEnded(Long receiverId, Long rideId) {
+        return Notification.builder()
+                .type(NotificationType.RIDE_ENDED)
+                .receiverId(receiverId)
+                .referenceId(rideId)
+                .message("카풀 운행이 종료되었습니다.")
+                .build();
+    }
+
+    public static Notification ofPostCancelled(Long receiverId, Long postId) {
+        return Notification.builder()
+                .type(NotificationType.POST_CANCELLED)
+                .receiverId(receiverId)
+                .referenceId(postId)
+                .message("신청한 카풀 게시글이 취소되었습니다.")
+                .build();
+    }
+
+    public void markAsRead() {
+        if (this.readAt == null) {
+            this.readAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package com.techeer.carpool.domain.notification.repository;
+
+import com.techeer.carpool.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
+
+    long countByReceiverIdAndReadAtIsNull(Long receiverId);
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/notification/service/NotificationService.java
@@ -1,0 +1,47 @@
+package com.techeer.carpool.domain.notification.service;
+
+import com.techeer.carpool.domain.notification.entity.Notification;
+import com.techeer.carpool.domain.notification.repository.NotificationRepository;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public void save(Notification notification) {
+        notificationRepository.save(notification);
+    }
+
+    @Transactional
+    public void saveAll(List<Notification> notifications) {
+        notificationRepository.saveAll(notifications);
+    }
+
+    public List<Notification> getNotifications(Long receiverId) {
+        return notificationRepository.findByReceiverIdOrderByCreatedAtDesc(receiverId);
+    }
+
+    public long getUnreadCount(Long receiverId) {
+        return notificationRepository.countByReceiverIdAndReadAtIsNull(receiverId);
+    }
+
+    @Transactional
+    public void markAsRead(Long receiverId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CarpoolException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        if (!notification.getReceiverId().equals(receiverId)) {
+            throw new CarpoolException(ErrorCode.NOTIFICATION_FORBIDDEN);
+        }
+        notification.markAsRead();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/post/application/service/ApplicationCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/application/service/ApplicationCreateService.java
@@ -6,7 +6,9 @@ import com.techeer.carpool.domain.post.application.repository.ApplicationReposit
 import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.notification.dto.NotificationPayload;
+import com.techeer.carpool.domain.notification.entity.Notification;
 import com.techeer.carpool.domain.notification.publisher.RedisNotificationPublisher;
+import com.techeer.carpool.domain.notification.service.NotificationService;
 import com.techeer.carpool.domain.notification.type.NotificationType;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.repository.PostRepository;
@@ -26,6 +28,7 @@ public class ApplicationCreateService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final RedisNotificationPublisher notificationPublisher;
+    private final NotificationService notificationService;
 
     @Transactional
     public ApplicationResponse apply(Long postId, Long applicantId) {
@@ -60,6 +63,7 @@ public class ApplicationCreateService {
                 .map(Member::getNickname)
                 .orElse("알 수 없음");
 
+        notificationService.save(Notification.ofApplicationReceived(post.getMemberId(), postId));
         notificationPublisher.publish(post.getMemberId(), NotificationPayload.builder()
                 .type(NotificationType.APPLICATION_RECEIVED)
                 .message(nickname + "님이 카풀을 신청했습니다.")

--- a/backend/src/main/java/com/techeer/carpool/domain/post/application/service/ApplicationStatusService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/application/service/ApplicationStatusService.java
@@ -7,7 +7,9 @@ import com.techeer.carpool.domain.post.application.repository.ApplicationReposit
 import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.notification.dto.NotificationPayload;
+import com.techeer.carpool.domain.notification.entity.Notification;
 import com.techeer.carpool.domain.notification.publisher.RedisNotificationPublisher;
+import com.techeer.carpool.domain.notification.service.NotificationService;
 import com.techeer.carpool.domain.notification.type.NotificationType;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.repository.PostRepository;
@@ -27,6 +29,7 @@ public class ApplicationStatusService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final RedisNotificationPublisher notificationPublisher;
+    private final NotificationService notificationService;
 
     @Transactional
     public ApplicationResponse accept(Long applicationId, Long requesterId) {
@@ -46,6 +49,7 @@ public class ApplicationStatusService {
         application.accept();
         post.incrementPassengers();
 
+        notificationService.save(Notification.ofApplicationAccepted(application.getApplicantId(), application.getPostId()));
         notificationPublisher.publish(application.getApplicantId(), NotificationPayload.builder()
                 .type(NotificationType.APPLICATION_ACCEPTED)
                 .message("카풀 신청이 승인되었습니다.")
@@ -68,6 +72,7 @@ public class ApplicationStatusService {
 
         application.reject();
 
+        notificationService.save(Notification.ofApplicationRejected(application.getApplicantId(), application.getPostId()));
         notificationPublisher.publish(application.getApplicantId(), NotificationPayload.builder()
                 .type(NotificationType.APPLICATION_REJECTED)
                 .message("카풀 신청이 거절되었습니다.")

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostDeleteService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostDeleteService.java
@@ -4,7 +4,9 @@ import com.techeer.carpool.domain.post.application.entity.Application;
 import com.techeer.carpool.domain.post.application.entity.ApplicationStatus;
 import com.techeer.carpool.domain.post.application.repository.ApplicationRepository;
 import com.techeer.carpool.domain.notification.dto.NotificationPayload;
+import com.techeer.carpool.domain.notification.entity.Notification;
 import com.techeer.carpool.domain.notification.publisher.RedisNotificationPublisher;
+import com.techeer.carpool.domain.notification.service.NotificationService;
 import com.techeer.carpool.domain.notification.type.NotificationType;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.repository.PostRepository;
@@ -25,6 +27,7 @@ public class PostDeleteService {
     private final PostRepository postRepository;
     private final ApplicationRepository applicationRepository;
     private final RedisNotificationPublisher notificationPublisher;
+    private final NotificationService notificationService;
 
     @Transactional
     public void deletePost(Long id, Long requesterId) {
@@ -41,6 +44,9 @@ public class PostDeleteService {
                 .map(Application::getApplicantId)
                 .collect(Collectors.toList());
 
+        notificationService.saveAll(applicantIds.stream()
+                .map(applicantId -> Notification.ofPostCancelled(applicantId, id))
+                .collect(Collectors.toList()));
         notificationPublisher.publishToMany(applicantIds, NotificationPayload.builder()
                 .type(NotificationType.POST_CANCELLED)
                 .message("신청한 카풀 게시글이 취소되었습니다.")

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -5,7 +5,9 @@ import com.techeer.carpool.domain.post.application.entity.ApplicationStatus;
 import com.techeer.carpool.domain.post.application.repository.ApplicationRepository;
 import com.techeer.carpool.domain.member.driver.repository.DriverRepository;
 import com.techeer.carpool.domain.notification.dto.NotificationPayload;
+import com.techeer.carpool.domain.notification.entity.Notification;
 import com.techeer.carpool.domain.notification.publisher.RedisNotificationPublisher;
+import com.techeer.carpool.domain.notification.service.NotificationService;
 import com.techeer.carpool.domain.notification.type.NotificationType;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.entity.PostStatus;
@@ -37,6 +39,7 @@ public class RideService {
     private final DriverRepository driverRepository;
     private final ApplicationRepository applicationRepository;
     private final RedisNotificationPublisher notificationPublisher;
+    private final NotificationService notificationService;
 
     @Transactional
     public RideResponse createRide(RideCreateRequest request, Long driverId) {
@@ -85,6 +88,9 @@ public class RideService {
         List<Long> passengerIds = ride.getPassengers().stream()
                 .map(RidePassenger::getPassengerId)
                 .collect(Collectors.toList());
+        notificationService.saveAll(passengerIds.stream()
+                .map(id -> Notification.ofRideStarted(id, rideId))
+                .collect(Collectors.toList()));
         notificationPublisher.publishToMany(passengerIds, NotificationPayload.builder()
                 .type(NotificationType.RIDE_STARTED)
                 .message("카풀 운행이 시작되었습니다.")
@@ -104,6 +110,9 @@ public class RideService {
         List<Long> passengerIds = ride.getPassengers().stream()
                 .map(RidePassenger::getPassengerId)
                 .collect(Collectors.toList());
+        notificationService.saveAll(passengerIds.stream()
+                .map(id -> Notification.ofRideEnded(id, rideId))
+                .collect(Collectors.toList()));
         notificationPublisher.publishToMany(passengerIds, NotificationPayload.builder()
                 .type(NotificationType.RIDE_ENDED)
                 .message("카풀 운행이 종료되었습니다.")

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -41,7 +41,10 @@ public enum ErrorCode {
     REVIEW_ALREADY_EXISTS("REVIEW_001", "이미 평가한 운행입니다.", HttpStatus.CONFLICT),
     REVIEW_FORBIDDEN("REVIEW_002", "평가 권한이 없습니다.", HttpStatus.FORBIDDEN),
     REVIEW_NOT_FOUND("REVIEW_003", "평가를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    REVIEW_RIDE_NOT_COMPLETED("REVIEW_004", "완료된 운행만 평가할 수 있습니다.", HttpStatus.CONFLICT);
+    REVIEW_RIDE_NOT_COMPLETED("REVIEW_004", "완료된 운행만 평가할 수 있습니다.", HttpStatus.CONFLICT),
+
+    NOTIFICATION_NOT_FOUND("NOTIFICATION_001", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOTIFICATION_FORBIDDEN("NOTIFICATION_002", "알림 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
 
     private final String code;


### PR DESCRIPTION
## 배경

기존 알림 시스템은 Redis pub/sub으로만 전송하여 클라이언트가 연결되지 않은 상태에서 발생한 알림은 영구 소실되었습니다. 알림을 DB에 저장하여 연결이 끊긴 동안 발생한 알림도 나중에 조회할 수 있도록 개선합니다.

## 변경 내용

### Notification 엔티티 추가

```
notification/
  entity/Notification.java         ← 신규 JPA 엔티티
  repository/NotificationRepository.java  ← 신규
  service/NotificationService.java        ← 신규
```

- `notifications` 테이블: `receiver_id`, `type`, `reference_id`, `message`, `read_at`, `created_at`
- `receiver_id`, `receiver_id + read_at` 복합 인덱스로 미읽음 조회 최적화
- `markAsRead()` 메서드로 읽음 처리

### 정적 팩토리 메서드로 알림 생성

Builder는 `private`으로 막고, 모든 생성은 의미 있는 이름의 정팩메로만 허용합니다.

```java
Notification.ofApplicationReceived(receiverId, postId)
Notification.ofApplicationAccepted(receiverId, postId)
Notification.ofApplicationRejected(receiverId, postId)
Notification.ofRideStarted(receiverId, rideId)
Notification.ofRideEnded(receiverId, rideId)
Notification.ofPostCancelled(receiverId, postId)
```

### 알림 발생 시점에 DB 저장 연동

| 이벤트 | 저장 위치 |
|--------|----------|
| 탑승 신청 접수 | `ApplicationCreateService` |
| 신청 수락 / 거절 | `ApplicationStatusService` |
| 게시글 취소 | `PostDeleteService` |
| 운행 시작 / 종료 | `RideService` |

## 알림 흐름 변경

**기존:** 이벤트 → Redis pub/sub → SSE 전송 (끝, 소실 가능)

**변경 후:** 이벤트 → **DB 저장** + Redis pub/sub → SSE 전송