### PR TITLE
fix: global 설정 보안 및 안정성 문제 수정

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package com.techeer.carpool.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.techeer.carpool.domain.notification.subscriber.RedisNotificationSubscriber;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -10,20 +12,28 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 public class RedisConfig {
 
     // StringRedisTemplate은 Spring Boot 자동 구성 사용 (별도 빈 불필요)
 
-    // 알림 페이로드 직렬화용 (JSON)
+    // Boot가 ObjectMapper를 자동 구성하지 않는 환경(테스트 등)을 위한 폴백
     @Bean
-    public RedisTemplate<String, Object> notificationRedisTemplate(RedisConnectionFactory factory) {
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    // 알림 페이로드 직렬화용 (JSON) — Boot가 자동 구성한 ObjectMapper 주입
+    @Bean
+    public RedisTemplate<String, Object> notificationRedisTemplate(
+            RedisConnectionFactory factory,
+            ObjectMapper objectMapper) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
         return template;
     }
 
@@ -39,11 +49,5 @@ public class RedisConfig {
                 new PatternTopic("notification:*")
         );
         return container;
-    }
-
-    // JSON 직렬화/역직렬화
-    @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper();
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import org.springframework.beans.factory.annotation.Value;
 import java.util.List;
 
 @Configuration
@@ -25,6 +26,9 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final BlacklistRedisRepository blacklistRedisRepository;
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigin;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -53,7 +57,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedOrigins(List.of(allowedOrigin));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/backend/src/main/java/com/techeer/carpool/global/config/WebSocketAuthChannelInterceptor.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/WebSocketAuthChannelInterceptor.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
+import org.springframework.messaging.MessagingException;
 
 @Component
 @RequiredArgsConstructor
@@ -21,13 +22,15 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
         if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
             String authHeader = accessor.getFirstNativeHeader("Authorization");
-            if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                String token = authHeader.substring(7);
-                if (jwtTokenProvider.validateToken(token)) {
-                    Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
-                    accessor.setUser(() -> String.valueOf(memberId));
-                }
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                throw new MessagingException("WebSocket 연결 실패: Authorization 헤더가 없습니다.");
             }
+            String token = authHeader.substring(7);
+            if (!jwtTokenProvider.validateToken(token)) {
+                throw new MessagingException("WebSocket 연결 실패: 유효하지 않은 토큰입니다.");
+            }
+            Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
+            accessor.setUser(() -> String.valueOf(memberId));
         }
         return message;
     }

--- a/backend/src/main/java/com/techeer/carpool/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.techeer.carpool.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -15,6 +16,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final WebSocketAuthChannelInterceptor authInterceptor;
 
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigin;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");
@@ -23,7 +27,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+        registry.addEndpoint("/ws").setAllowedOriginPatterns(allowedOrigin);
     }
 
     @Override

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -406,9 +406,13 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .carNumber("12가3456")
                 .build());
 
+        VehicleOption adminVehicle = vehicleOptions.stream()
+                .filter(v -> "기아".equals(v.getBrand()) && "K5".equals(v.getModel()))
+                .findFirst()
+                .orElse(vehicleOptions.get(0));
         driverRepository.save(Driver.builder()
                 .memberId(admin.getId())
-                .vehicleOptionId(vehicleOptions.get(8).getId())
+                .vehicleOptionId(adminVehicle.getId())
                 .carNumber("99나8765")
                 .build());
     }

--- a/backend/src/main/java/com/techeer/carpool/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/techeer/carpool/global/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.techeer.carpool.global.jwt;
 
 import com.techeer.carpool.domain.auth.repository.BlacklistRedisRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,24 +30,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         String token = resolveToken(request);
 
-        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-            // Redis 장애 시 fail-open: 블랙리스트 체크 실패해도 요청 허용
+        if (StringUtils.hasText(token)) {
             try {
-                if (blacklistRedisRepository.isBlacklisted(token)) {
+                if (isBlacklisted(token)) {
                     filterChain.doFilter(request, response);
                     return;
                 }
-            } catch (Exception e) {
-                log.warn("Redis 블랙리스트 조회 실패, 요청 허용: {}", e.getMessage());
+                Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(memberId, null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (ExpiredJwtException e) {
+                request.setAttribute("tokenError", "AUTH_005");
+            } catch (JwtException | IllegalArgumentException e) {
+                request.setAttribute("tokenError", "AUTH_004");
             }
-
-            Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(memberId, null, List.of());
-            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isBlacklisted(String token) {
+        try {
+            return blacklistRedisRepository.isBlacklisted(token);
+        } catch (Exception e) {
+            log.error("Redis 블랙리스트 조회 실패 — 로그아웃된 토큰이 허용될 수 있음: {}", e.getMessage());
+            return false;
+        }
     }
 
     public String resolveToken(HttpServletRequest request) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,6 +25,9 @@ jwt:
   refresh-token-expiration: 604800000  # 7일
   cookie-secure: true
 
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
+
 management:
   endpoints:
     web:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -14,3 +14,6 @@ jwt:
   access-token-expiration: 900000
   refresh-token-expiration: 604800000
   cookie-secure: false
+
+cors:
+  allowed-origins: http://localhost:5173


### PR DESCRIPTION
## 발생 배경

WebSocket과 Redis를 도입하면서 기존 HTTP 인증/CORS 정책이 새로운 채널에 일관되게 적용되지 않았고, Redis 설정 과정에서 Spring Boot 자동 구성에 대한 이해 부족으로 중복 빈이 등록되었습니다.

---

## 수정 내용

### #1 CORS 허용 출처 하드코딩
- **문제**: `SecurityConfig`에 `http://localhost:5173` 하드코딩 → 배포 환경에서 프론트 도메인 변경 시 대응 불가
- **해결**: `${CORS_ALLOWED_ORIGINS:http://localhost:5173}` 환경변수로 분리

### #2 WebSocket CORS 정책 불일치
- **문제**: `WebSocketConfig`에서 `setAllowedOriginPatterns("*")` → HTTP CORS는 특정 출처만 허용인데 WebSocket은 전체 허용
- **해결**: HTTP CORS와 동일한 환경변수 적용

### #3 WebSocket 인증 실패 시 연결 허용
- **문제**: `WebSocketAuthChannelInterceptor`에서 JWT가 없거나 유효하지 않아도 연결이 그대로 통과
- **해결**: 인증 실패 시 `MessagingException` 던져 연결 차단

### #4 #5 JWT 필터 만료/위변조 미구분 및 로그 레벨
- **문제**: `JwtAuthenticationFilter`에서 토큰 만료(`AUTH_005`)와 위변조(`AUTH_004`)를 구분하지 않음, 블랙리스트 조회 실패 시 `warn` 레벨로 위험성 낮게 표현
- **해결**: `ExpiredJwtException` / `JwtException` 분리 처리, 로그 레벨 `error`로 상향

### #6 ObjectMapper 중복 빈 등록
- **문제**: `RedisConfig`에서 `ObjectMapper @Bean`을 직접 생성 → Spring Boot가 이미 자동 구성한 빈과 중복
- **해결**: `@ConditionalOnMissingBean`으로 폴백 처리, 운영 환경에서는 Boot 자동 구성 빈 주입

### #7 LocalDataInitializer 하드코딩 인덱스
- **문제**: `vehicleOptions.get(8)` → CarColor enum 수가 바뀌면 `IndexOutOfBoundsException` 발생 가능
- **해결**: 브랜드/모델 명시 스트림 조회로 변경

### 테스트 환경 수정
- `test/application.yml`에 `cors.allowed-origins` 누락 → 컨텍스트 로딩 실패 수정