### PR TITLE
refactor: 프로필 조회 인가 로직을 서비스 → 컨트롤러로 이동

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
@@ -5,6 +5,8 @@ import com.techeer.carpool.domain.member.dto.ProfileUpdateRequest;
 import com.techeer.carpool.domain.member.service.MemberProfileService;
 import com.techeer.carpool.domain.member.service.MemberWithdrawService;
 import com.techeer.carpool.global.common.ApiResponse;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,14 +26,17 @@ public class MemberController {
             @PathVariable Long id,
             Authentication authentication) {
         Long requesterId = (Long) authentication.getPrincipal();
-        ProfileResponse profile = memberProfileService.getProfile(requesterId, id);
+        if (!requesterId.equals(id)) {
+            throw new CarpoolException(ErrorCode.MEMBER_FORBIDDEN);
+        }
+        ProfileResponse profile = memberProfileService.getProfile(id);
         return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
     }
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<ProfileResponse>> getProfile(Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
-        ProfileResponse profile = memberProfileService.getProfile(memberId, memberId);
+        ProfileResponse profile = memberProfileService.getProfile(memberId);
         return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
     }
 

--- a/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberProfileService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberProfileService.java
@@ -18,11 +18,7 @@ public class MemberProfileService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public ProfileResponse getProfile(Long requesterId, Long memberId) {
-        if (!requesterId.equals(memberId)) {
-            throw new CarpoolException(ErrorCode.MEMBER_FORBIDDEN);
-        }
-
+    public ProfileResponse getProfile(Long memberId) {
         Member member = memberRepository.findByIdAndDeletedFalse(memberId)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.MEMBER_NOT_FOUND));
         return ProfileResponse.from(member);


### PR DESCRIPTION
## 문제

`GET /me` 엔드포인트에서 동일한 `memberId`를 두 번 넘기는 어색한 구조:

```java
// 컨트롤러
memberProfileService.getProfile(memberId, memberId); // 같은 값을 두 번

// 서비스 - /me 호출 시 이 체크는 항상 통과
if (!requesterId.equals(memberId)) {
    throw new CarpoolException(ErrorCode.MEMBER_FORBIDDEN);
}
```

서비스가 인가(Authorization) 로직을 담당한 것이 근본 원인.

## 변경 사항

- `MemberProfileService.getProfile(requesterId, memberId)` → `getProfile(memberId)` 로 단순화
- `GET /{id}` 컨트롤러에서 직접 `requesterId != id` 검증
- `GET /me`는 `memberId` 단일 인자로 호출

## 개선 효과

| | 이전 | 이후 |
|---|---|---|
| 서비스 책임 | 인가 + 조회 | 조회만 |
| /me 호출 | `getProfile(id, id)` | `getProfile(id)` |
| 인가 위치 | Service | Controller |