### PR TITLE
refactor: member 도메인 품질 개선 (#84)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/auth/service/MemberLoginService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/service/MemberLoginService.java
@@ -22,8 +22,7 @@ public class MemberLoginService {
     private final JwtTokenProvider jwtTokenProvider;
 
     public AuthTokens login(LoginRequest request) {
-        Member member = memberRepository.findByEmail(request.getEmail())
-                .filter(m -> !m.isDeleted())
+        Member member = memberRepository.findByEmailAndDeletedFalse(request.getEmail())
                 .orElseThrow(() -> new CarpoolException(ErrorCode.MEMBER_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {

--- a/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
@@ -20,18 +20,15 @@ public class MemberController {
     private final MemberWithdrawService memberWithdrawService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<ProfileResponse>> getProfileById(
-            @PathVariable Long id,
-            Authentication authentication) {
-        Long requesterId = (Long) authentication.getPrincipal();
-        ProfileResponse profile = memberProfileService.getProfile(requesterId, id);
+    public ResponseEntity<ApiResponse<ProfileResponse>> getProfileById(@PathVariable Long id) {
+        ProfileResponse profile = memberProfileService.getProfile(id);
         return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
     }
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<ProfileResponse>> getProfile(Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
-        ProfileResponse profile = memberProfileService.getProfile(memberId, memberId);
+        ProfileResponse profile = memberProfileService.getProfile(memberId);
         return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
     }
 

--- a/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileResponse.java
@@ -13,6 +13,7 @@ public class ProfileResponse {
     private Long id;
     private String email;
     private String nickname;
+    private double averageRating;
     private LocalDateTime createdAt;
 
     public static ProfileResponse from(Member member) {
@@ -20,6 +21,7 @@ public class ProfileResponse {
                 .id(member.getId())
                 .email(member.getEmail())
                 .nickname(member.getNickname())
+                .averageRating(member.getAverageRating())
                 .createdAt(member.getCreatedAt())
                 .build();
     }

--- a/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileUpdateRequest.java
@@ -16,7 +16,7 @@ public class ProfileUpdateRequest {
     private String newPassword;
 
     @AssertTrue(message = "비밀번호 변경 시 현재 비밀번호가 필요합니다.")
-    private boolean isPasswordChangeValid() {
+    public boolean isPasswordChangeValid() {
         return newPassword == null || (currentPassword != null && !currentPassword.isBlank());
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/dto/ProfileUpdateRequest.java
@@ -1,16 +1,22 @@
 package com.techeer.carpool.domain.member.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class ProfileUpdateRequest {
 
-    @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
+    @Size(min = 1, max = 50, message = "닉네임은 1자 이상 50자 이하여야 합니다.")
     private String nickname;
 
     private String currentPassword;
 
     @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
     private String newPassword;
+
+    @AssertTrue(message = "비밀번호 변경 시 현재 비밀번호가 필요합니다.")
+    private boolean isPasswordChangeValid() {
+        return newPassword == null || (currentPassword != null && !currentPassword.isBlank());
+    }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/entity/Member.java
@@ -1,6 +1,8 @@
 package com.techeer.carpool.domain.member.entity;
 
 import com.techeer.carpool.global.common.entity.SoftDeletableEntity;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,6 +43,9 @@ public class Member extends SoftDeletableEntity {
     }
 
     public void addRating(int rating) {
+        if (rating < 1 || rating > 5) {
+            throw new CarpoolException(ErrorCode.INVALID_INPUT);
+        }
         this.totalRatingSum += rating;
         this.reviewCount++;
     }
@@ -50,6 +55,9 @@ public class Member extends SoftDeletableEntity {
     }
 
     public void updateNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new CarpoolException(ErrorCode.INVALID_INPUT);
+        }
         this.nickname = nickname;
     }
 
@@ -57,7 +65,6 @@ public class Member extends SoftDeletableEntity {
         this.password = encodedPassword;
     }
 
-    // 탈퇴 관련 로직 추가를 위해 유지
     public void withdraw() {
         delete();
     }

--- a/backend/src/main/java/com/techeer/carpool/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/repository/MemberRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByEmail(String email);
+
     Optional<Member> findByEmailAndDeletedFalse(String email);
 
     Optional<Member> findByIdAndDeletedFalse(Long id);

--- a/backend/src/main/java/com/techeer/carpool/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/repository/MemberRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndDeletedFalse(String email);
 
     Optional<Member> findByIdAndDeletedFalse(Long id);
 

--- a/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberProfileService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberProfileService.java
@@ -18,11 +18,8 @@ public class MemberProfileService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public ProfileResponse getProfile(Long requesterId, Long memberId) {
-        if (!requesterId.equals(memberId)) {
-            throw new CarpoolException(ErrorCode.MEMBER_FORBIDDEN);
-        }
-
+    @Transactional(readOnly = true)
+    public ProfileResponse getProfile(Long memberId) {
         Member member = memberRepository.findByIdAndDeletedFalse(memberId)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.MEMBER_NOT_FOUND));
         return ProfileResponse.from(member);

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
 
     EMAIL_DUPLICATE("AUTH_001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
-    MEMBER_NOT_FOUND("AUTH_002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    MEMBER_NOT_FOUND("MEMBER_002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_CREDENTIALS("AUTH_003", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_TOKEN("AUTH_004", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_TOKEN("AUTH_005", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),

--- a/backend/src/test/java/com/techeer/carpool/domain/auth/AuthIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/auth/AuthIntegrationTest.java
@@ -139,7 +139,7 @@ class AuthIntegrationTest {
                                 "password", "password123"
                         ))))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("AUTH_002"));
+                .andExpect(jsonPath("$.code").value("MEMBER_002"));
     }
 
     @Test
@@ -177,7 +177,7 @@ class AuthIntegrationTest {
                                 "password", "password123"
                         ))))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("AUTH_002"));
+                .andExpect(jsonPath("$.code").value("MEMBER_002"));
     }
 
     // ── 토큰 재발급 ──────────────────────────────────────────

--- a/backend/src/test/java/com/techeer/carpool/domain/member/MemberIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/carpool/domain/member/MemberIntegrationTest.java
@@ -90,12 +90,12 @@ class MemberIntegrationTest {
     }
 
     @Test
-    @DisplayName("ID로 타인 프로필 조회 실패 - 403")
-    void getProfileById_other_forbidden() throws Exception {
+    @DisplayName("ID로 타인 프로필 조회 성공")
+    void getProfileById_other_success() throws Exception {
         mockMvc.perform(get("/api/v1/members/{id}", otherMemberId)
                         .header("Authorization", token))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code").value("MEMBER_001"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(otherMemberId));
     }
 
     // ── 프로필 수정 ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #84

- `MEMBER_NOT_FOUND` 에러코드 접두사 `AUTH_002` → `MEMBER_002` 수정
- `GET /members/{id}` 타인 프로필 조회 허용 (`FORBIDDEN` 제거), `getProfile` readOnly 트랜잭션 추가
- `ProfileUpdateRequest` 닉네임 빈 문자열 차단, 비밀번호 변경 시 현재 비밀번호 필수 cross-field 검증 추가 (`@AssertTrue`)
- 탈퇴 회원 로그인 필터를 in-memory `filter()` → DB 쿼리 레벨 `findByEmailAndDeletedFalse`로 이동
- `LocalDataInitializer` 호환을 위해 `findByEmail` 유지 (두 메서드 공존)
- `ProfileResponse`에 `averageRating` 필드 누락 추가
- `Member.addRating()` 1~5 범위 외 값 입력 시 `INVALID_INPUT` 예외 발생 (entity 불변식)
- `Member.updateNickname()` null/빈 문자열 입력 시 `INVALID_INPUT` 예외 발생 (entity 불변식)
- `Member.withdraw()` 불필요한 주석 제거

## Test plan

- [ ] `GET /api/v1/members/me` — 인증된 사용자 프로필 조회, `averageRating` 포함 확인
- [ ] `GET /api/v1/members/{id}` — 타인 ID로 조회 시 200 OK
- [ ] `PUT /api/v1/members/me` — 빈 닉네임(`""`) 요청 시 400 반환
- [ ] `PUT /api/v1/members/me` — `newPassword` 있고 `currentPassword` 없으면 400 반환
- [ ] 탈퇴 회원 이메일로 로그인 시 `MEMBER_002` 에러 반환
- [ ] `MemberIntegrationTest` 전체 통과