### PR TITLE
feat: Tag 엔티티 마이그레이션 (Issue #86)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/post/controller/TagController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/controller/TagController.java
@@ -1,0 +1,25 @@
+package com.techeer.carpool.domain.post.controller;
+
+import com.techeer.carpool.domain.post.dto.TagResponse;
+import com.techeer.carpool.domain.post.service.TagReadService;
+import com.techeer.carpool.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/tags")
+@RequiredArgsConstructor
+public class TagController {
+
+    private final TagReadService tagReadService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TagResponse>>> getAllTags() {
+        return ResponseEntity.ok(ApiResponse.of("태그 목록 조회 성공", tagReadService.getAllTags()));
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostCreateRequest.java
@@ -39,5 +39,5 @@ public class PostCreateRequest {
     private String description;
     private boolean autoAccept;
     private Integer price;
-    private List<String> tags;
+    private List<Long> tagIds;
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostResponse.java
@@ -29,7 +29,7 @@ public class PostResponse {
     private String description;
     private boolean autoAccept;
     private Integer price;
-    private List<String> tags;
+    private List<TagResponse> tags;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -52,7 +52,7 @@ public class PostResponse {
                 .description(post.getDescription())
                 .autoAccept(post.isAutoAccept())
                 .price(post.getPrice())
-                .tags(post.getTags())
+                .tags(post.getTags().stream().map(TagResponse::from).toList())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostUpdateRequest.java
@@ -41,5 +41,5 @@ public class PostUpdateRequest {
     private boolean autoAccept;
     private PostStatus status;
     private Integer price;
-    private List<String> tags;
+    private List<Long> tagIds;
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/TagResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/TagResponse.java
@@ -1,0 +1,20 @@
+package com.techeer.carpool.domain.post.dto;
+
+import com.techeer.carpool.domain.post.entity.Tag;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TagResponse {
+
+    private Long id;
+    private String name;
+
+    public static TagResponse from(Tag tag) {
+        return TagResponse.builder()
+                .id(tag.getId())
+                .name(tag.getName())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -63,10 +63,13 @@ public class Post extends SoftDeletableEntity {
 
     private Integer price;
 
-    @ElementCollection
-    @CollectionTable(name = "post_tags", joinColumns = @JoinColumn(name = "post_id"))
-    @Column(name = "tag")
-    private List<String> tags = new ArrayList<>();
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "post_tags",
+            joinColumns = @JoinColumn(name = "post_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private List<Tag> tags = new ArrayList<>();
 
     @PrePersist
     private void prePersist() {
@@ -80,7 +83,7 @@ public class Post extends SoftDeletableEntity {
                 String destinationLocation, Double destinationLat, Double destinationLng,
                 LocalDateTime departureTime, int maxPassengers,
                 String description, boolean autoAccept,
-                Integer price, List<String> tags) {
+                Integer price, List<Tag> tags) {
         this.memberId = memberId;
         this.title = title;
         this.departureLocation = departureLocation;

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/PostUpdateCommand.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/PostUpdateCommand.java
@@ -17,5 +17,5 @@ public record PostUpdateCommand(
         boolean autoAccept,
         PostStatus status,
         Integer price,
-        List<String> tags
+        List<Tag> tags
 ) {}

--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Tag.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Tag.java
@@ -1,0 +1,28 @@
+package com.techeer.carpool.domain.post.entity;
+
+import com.techeer.carpool.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "tags")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Tag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    @Builder
+    public Tag(String name) {
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    List<Post> findByDeletedFalseOrderByCreatedAtDesc();
+    @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.tags WHERE p.deleted = false ORDER BY p.createdAt DESC")
+    List<Post> findByDeletedFalseWithTagsOrderByCreatedAtDesc();
 
     Optional<Post> findByIdAndDeletedFalse(Long id);
 

--- a/backend/src/main/java/com/techeer/carpool/domain/post/repository/TagRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/repository/TagRepository.java
@@ -1,0 +1,11 @@
+package com.techeer.carpool.domain.post.repository;
+
+import com.techeer.carpool.domain.post.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    List<Tag> findAllByIdIn(List<Long> ids);
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCreateService.java
@@ -5,10 +5,14 @@ import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.dto.PostCreateRequest;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.entity.Tag;
 import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.domain.post.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,9 +20,13 @@ public class PostCreateService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final TagRepository tagRepository;
 
     @Transactional
     public PostResponse createPost(PostCreateRequest request, Long memberId) {
+        List<Tag> tags = tagRepository.findAllByIdIn(
+                request.getTagIds() != null ? request.getTagIds() : List.of()
+        );
         Post post = Post.builder()
                 .memberId(memberId)
                 .title(request.getTitle())
@@ -33,7 +41,7 @@ public class PostCreateService {
                 .description(request.getDescription())
                 .autoAccept(request.isAutoAccept())
                 .price(request.getPrice())
-                .tags(request.getTags())
+                .tags(tags)
                 .build();
         Post saved = postRepository.save(post);
         String nickname = memberRepository.findById(saved.getMemberId())

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostReadService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostReadService.java
@@ -25,7 +25,7 @@ public class PostReadService {
     private final MemberRepository memberRepository;
 
     public List<PostResponse> getAllPosts() {
-        List<Post> posts = postRepository.findByDeletedFalseOrderByCreatedAtDesc();
+        List<Post> posts = postRepository.findByDeletedFalseWithTagsOrderByCreatedAtDesc();
         Set<Long> memberIds = posts.stream().map(Post::getMemberId).collect(Collectors.toSet());
         Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
                 .collect(Collectors.toMap(Member::getId, Member::getNickname));

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpdateService.java
@@ -5,13 +5,17 @@ import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.dto.PostResponse;
 import com.techeer.carpool.domain.post.dto.PostUpdateRequest;
 import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.entity.Tag;
 import com.techeer.carpool.domain.post.entity.PostUpdateCommand;
 import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.domain.post.repository.TagRepository;
 import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +23,7 @@ public class PostUpdateService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final TagRepository tagRepository;
 
     @Transactional
     public PostResponse updatePost(Long id, PostUpdateRequest request, Long requesterId) {
@@ -27,6 +32,9 @@ public class PostUpdateService {
         if (!post.getMemberId().equals(requesterId)) {
             throw new CarpoolException(ErrorCode.POST_FORBIDDEN);
         }
+        List<Tag> tags = tagRepository.findAllByIdIn(
+                request.getTagIds() != null ? request.getTagIds() : List.of()
+        );
         post.updateFrom(new PostUpdateCommand(
                 request.getTitle(),
                 request.getDepartureLocation(),
@@ -41,7 +49,7 @@ public class PostUpdateService {
                 request.isAutoAccept(),
                 request.getStatus(),
                 request.getPrice(),
-                request.getTags()
+                tags
         ));
         String nickname = memberRepository.findById(post.getMemberId())
                 .map(Member::getNickname)

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/TagReadService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/TagReadService.java
@@ -1,0 +1,23 @@
+package com.techeer.carpool.domain.post.service;
+
+import com.techeer.carpool.domain.post.dto.TagResponse;
+import com.techeer.carpool.domain.post.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagReadService {
+
+    private final TagRepository tagRepository;
+
+    public List<TagResponse> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(TagResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/vehicles/**").permitAll()
+                        .requestMatchers("/api/v1/tags").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -44,7 +44,9 @@ public enum ErrorCode {
     REVIEW_RIDE_NOT_COMPLETED("REVIEW_004", "완료된 운행만 평가할 수 있습니다.", HttpStatus.CONFLICT),
 
     NOTIFICATION_NOT_FOUND("NOTIFICATION_001", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    NOTIFICATION_FORBIDDEN("NOTIFICATION_002", "알림 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    NOTIFICATION_FORBIDDEN("NOTIFICATION_002", "알림 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    TAG_NOT_FOUND("TAG_001", "태그를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
 
     private final String code;

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -10,7 +10,9 @@ import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.entity.PostStatus;
+import com.techeer.carpool.domain.post.entity.Tag;
 import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.domain.post.repository.TagRepository;
 import com.techeer.carpool.domain.review.entity.Review;
 import com.techeer.carpool.domain.review.repository.ReviewRepository;
 import com.techeer.carpool.domain.ride.entity.Ride;
@@ -32,6 +34,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Profile("local")
@@ -49,6 +53,7 @@ public class LocalDataInitializer implements CommandLineRunner {
     private final PasswordEncoder passwordEncoder;
     private final VehicleOptionRepository vehicleOptionRepository;
     private final DriverRepository driverRepository;
+    private final TagRepository tagRepository;
 
     @Override
     public void run(String... args) {
@@ -57,9 +62,11 @@ public class LocalDataInitializer implements CommandLineRunner {
 
         seedDrivers(test, admin, initVehicleOptions());
 
-        List<Post> allPosts = postRepository.findByDeletedFalseOrderByCreatedAtDesc();
+        Map<String, Tag> tagMap = seedTags();
+
+        List<Post> allPosts = postRepository.findByDeletedFalseWithTagsOrderByCreatedAtDesc();
         if (allPosts.isEmpty()) {
-            allPosts = seedPosts(test, admin);
+            allPosts = seedPosts(test, admin, tagMap);
         }
 
         if (rideRepository.count() == 0) {
@@ -71,9 +78,27 @@ public class LocalDataInitializer implements CommandLineRunner {
         log.info("[LocalDataInitializer] 초기 데이터 생성 완료");
     }
 
+    // ── Tags ───────────────────────────────────────────────────────────────────
+
+    private Map<String, Tag> seedTags() {
+        if (tagRepository.count() > 0) {
+            return tagRepository.findAll().stream()
+                    .collect(Collectors.toMap(Tag::getName, t -> t));
+        }
+        List<Tag> tags = tagRepository.saveAll(List.of(
+                Tag.builder().name("금연").build(),
+                Tag.builder().name("조용한 분위기").build(),
+                Tag.builder().name("반려동물").build(),
+                Tag.builder().name("짐 있음").build(),
+                Tag.builder().name("여성전용").build(),
+                Tag.builder().name("흡연").build()
+        ));
+        return tags.stream().collect(Collectors.toMap(Tag::getName, t -> t));
+    }
+
     // ── Posts ──────────────────────────────────────────────────────────────────
 
-    private List<Post> seedPosts(Member test, Member admin) {
+    private List<Post> seedPosts(Member test, Member admin, Map<String, Tag> tagMap) {
 
         // ① OPEN — 신청 모집 중 (admin 드라이버)
         Post p1 = postRepository.save(Post.builder()
@@ -88,7 +113,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .description("정시 출발합니다. 짐 많으신 분은 미리 말씀해 주세요.")
                 .autoAccept(false)
                 .price(5000)
-                .tags(List.of("NON_SMOKER", "QUIET"))
+                .tags(List.of(tagMap.get("금연"), tagMap.get("조용한 분위기")))
                 .build());
 
         // ② OPEN — 신청 모집 중 (test 드라이버)
@@ -104,7 +129,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .description("경유지 없이 직행입니다.")
                 .autoAccept(true)
                 .price(3000)
-                .tags(List.of("PET_OK", "LUGGAGE_OK"))
+                .tags(List.of(tagMap.get("반려동물"), tagMap.get("짐 있음")))
                 .build());
 
         // ③ CLOSED → SCHEDULED 운행 (약 20분 후 출발 — 30분 전 위치 공유 테스트용, test 드라이버)
@@ -120,7 +145,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .description("출발 20분 전 — 위치 공유 창 테스트용입니다.")
                 .autoAccept(false)
                 .price(4000)
-                .tags(List.of("NON_SMOKER"))
+                .tags(List.of(tagMap.get("금연")))
                 .build());
 
         // ④ CLOSED → IN_PROGRESS 운행 중 (admin 드라이버, test 탑승 중)
@@ -136,7 +161,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .description("현재 운행 중 — ActiveRidePanel 테스트용")
                 .autoAccept(true)
                 .price(3500)
-                .tags(List.of("QUIET"))
+                .tags(List.of(tagMap.get("조용한 분위기")))
                 .build());
 
         // ⑤ CLOSED → COMPLETED (test 드라이버, admin 탑승 완료 + 평점 등록됨)
@@ -167,7 +192,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .description("과거 완료 운행 — 평점 미등록 케이스 (★ 평가하기 버튼 표시)")
                 .autoAccept(true)
                 .price(15000)
-                .tags(List.of("LUGGAGE_OK"))
+                .tags(List.of(tagMap.get("짐 있음")))
                 .build());
 
         // test 유저 소유 게시글 추가 (관리자가 신청할 대상)


### PR DESCRIPTION
## Summary

- `@ElementCollection List<String> tags`를 `@ManyToMany List<Tag>` 관계로 마이그레이션
- Tag 엔티티 도입으로 태그 ID 기반 검색/필터 기반 마련
- N+1 문제 방지를 위한 fetch join 쿼리 추가

## 변경 내용

### 새로 추가된 파일
- `Tag` 엔티티 (`id`, `name`)
- `TagRepository` (`findAllByIdIn`)
- `TagResponse` DTO
- `TagReadService` (전체 태그 목록 조회)
- `TagController` (`GET /api/v1/tags`)

### 수정된 파일
- `Post` — `@ElementCollection List<String>` → `@ManyToMany List<Tag>`
- `PostUpdateCommand` — `List<String>` → `List<Tag>`
- `PostCreateRequest` / `PostUpdateRequest` — `List<String> tags` → `List<Long> tagIds`
- `PostResponse` — `List<String>` → `List<TagResponse>`
- `PostCreateService` / `PostUpdateService` — TagRepository로 tagIds → Tag 변환
- `PostRepository` — fetch join 쿼리 추가 (N+1 방지)
- `PostReadService` — fetch join 메서드 사용
- `SecurityConfig` — `GET /api/v1/tags` permitAll 추가
- `ErrorCode` — `TAG_NOT_FOUND` 추가
- `LocalDataInitializer` — Tag seed 추가, Post 생성 시 Tag 엔티티 전달

## Test plan

- [ ] 앱 정상 기동 확인 (local 프로파일)
- [ ] `tags` 테이블에 6개 행 존재 확인
- [ ] `GET /api/v1/tags` 토큰 없이 200 응답 확인
- [ ] `POST /api/v1/posts` body `"tagIds": [1, 3]` → 201, tags 포함 확인
- [ ] `GET /api/v1/posts/{id}` → `tags: [{"id":1,"name":"금연"}]` 형태 확인
- [ ] `PUT /api/v1/posts/{id}` tagIds 변경 → 응답 tags 변경 확인
- [ ] 목록 조회 시 SQL 로그에서 tags 쿼리 1회만 발생 확인
- [ ] 기존 게시글 생성/수정/삭제 API 회귀 없음 확인

Closes #86