### PR TITLE
refactor: Post 신청 처리 비관적 락 → 낙관적 락 전환 (close #94)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/entity/Post.java
@@ -24,6 +24,9 @@ public class Post extends SoftDeletableEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @Column(nullable = false)
     private Long memberId;
 

--- a/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
@@ -20,7 +20,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.tags WHERE p.id = :id AND p.deleted = false")
     Optional<Post> findByIdAndDeletedFalseWithTags(@Param("id") Long id);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.OPTIMISTIC)
     @Query("SELECT p FROM Post p WHERE p.id = :id AND p.deleted = false")
     Optional<Post> findByIdAndDeletedFalseWithLock(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     MEMBER_FORBIDDEN("MEMBER_001", "본인의 프로필만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
 
     POST_ALREADY_CLOSED("POST_003", "이미 마감된 게시글입니다.", HttpStatus.CONFLICT),
+    POST_CONFLICT("POST_004", "다른 요청과 충돌이 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.CONFLICT),
 
     REVIEW_ALREADY_EXISTS("REVIEW_001", "이미 평가한 운행입니다.", HttpStatus.CONFLICT),
     REVIEW_FORBIDDEN("REVIEW_002", "평가 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/backend/src/main/java/com/techeer/carpool/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/techeer/carpool/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.techeer.carpool.global.exception;
 import com.techeer.carpool.global.common.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,6 +15,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CarpoolException.class)
     public ResponseEntity<ErrorResponse> handleCarpoolException(CarpoolException e) {
         ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ErrorResponse> handleOptimisticLockingException(ObjectOptimisticLockingFailureException e) {
+        ErrorCode errorCode = ErrorCode.POST_CONFLICT;
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()));


### PR DESCRIPTION
## Summary

- `Post` 엔티티에 `@Version` 필드 추가로 낙관적 락 기반 충돌 감지 도입
- `PostRepository`: `PESSIMISTIC_WRITE` → `OPTIMISTIC` 락으로 변경 (DB 행 잠금 제거)
- `ErrorCode`: `POST_CONFLICT` (POST_004, 409) 추가
- `GlobalExceptionHandler`: `ObjectOptimisticLockingFailureException` 캐치 → 409 응답 처리

## Test plan

- [ ] 단일 신청 정상 처리 확인
- [ ] 동시 신청 충돌 시 409 응답 반환 확인
- [ ] 신청 승인(accept) 동시 요청 충돌 시 409 응답 반환 확인

Closes #94