### PR TITLE
fix: 회원 탈퇴 시 AccessToken 블랙리스트 처리 추가

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
@@ -5,10 +5,12 @@ import com.techeer.carpool.domain.member.dto.ProfileUpdateRequest;
 import com.techeer.carpool.domain.member.service.MemberProfileService;
 import com.techeer.carpool.domain.member.service.MemberWithdrawService;
 import com.techeer.carpool.global.common.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -42,9 +44,20 @@ public class MemberController {
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse<Void>> withdraw(Authentication authentication) {
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+            Authentication authentication,
+            HttpServletRequest request) {
         Long memberId = (Long) authentication.getPrincipal();
-        memberWithdrawService.withdraw(memberId);
+        String token = resolveToken(request);
+        memberWithdrawService.withdraw(memberId, token);
         return ResponseEntity.ok(ApiResponse.of("회원 탈퇴가 완료되었습니다."));
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberWithdrawService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/service/MemberWithdrawService.java
@@ -3,6 +3,7 @@ package com.techeer.carpool.domain.member.service;
 import com.techeer.carpool.domain.application.entity.Application;
 import com.techeer.carpool.domain.application.entity.ApplicationStatus;
 import com.techeer.carpool.domain.application.repository.ApplicationRepository;
+import com.techeer.carpool.domain.auth.repository.BlacklistRedisRepository;
 import com.techeer.carpool.domain.auth.repository.RefreshTokenRedisRepository;
 import com.techeer.carpool.domain.driver.repository.DriverRepository;
 import com.techeer.carpool.domain.member.entity.Member;
@@ -11,6 +12,7 @@ import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.repository.PostRepository;
 import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
+import com.techeer.carpool.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,12 +25,14 @@ public class MemberWithdrawService {
 
     private final MemberRepository memberRepository;
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final BlacklistRedisRepository blacklistRedisRepository;
+    private final JwtTokenProvider jwtTokenProvider;
     private final PostRepository postRepository;
     private final ApplicationRepository applicationRepository;
     private final DriverRepository driverRepository;
 
     @Transactional
-    public void withdraw(Long memberId) {
+    public void withdraw(Long memberId, String accessToken) {
         Member member = memberRepository.findByIdAndDeletedFalse(memberId)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -44,5 +48,10 @@ public class MemberWithdrawService {
 
         member.withdraw();
         refreshTokenRedisRepository.delete(memberId);
+
+        if (accessToken != null) {
+            long remaining = jwtTokenProvider.getRemainingSeconds(accessToken);
+            blacklistRedisRepository.add(accessToken, remaining);
+        }
     }
 }


### PR DESCRIPTION
## 관련 이슈
closes #102

## 변경 사항
탈퇴 후 만료되지 않은 AccessToken으로 인증 필요 API를 호출할 수 있는 보안 취약점 수정.

**MemberWithdrawService**
- `BlacklistRedisRepository`, `JwtTokenProvider` 의존성 주입 추가
- `withdraw(Long memberId)` → `withdraw(Long memberId, String accessToken)` 시그니처 변경
- RefreshToken 삭제 후 AccessToken 남은 만료 시간만큼 Redis 블랙리스트 등록

**MemberController**
- `DELETE /api/v1/members/me`에서 Authorization 헤더 파싱해 서비스로 전달

## 참조 패턴
`AuthController.logout()`의 블랙리스트 처리 로직과 동일 방식 적용