### PR TITLE
feat: 게시글 조회 응답에 드라이버 평점(driverAverageRating) 추가

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/driver/repository/DriverRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/driver/repository/DriverRepository.java
@@ -3,11 +3,15 @@ package com.techeer.carpool.domain.driver.repository;
 import com.techeer.carpool.domain.driver.entity.Driver;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface DriverRepository extends JpaRepository<Driver, Long> {
 
     Optional<Driver> findByMemberIdAndDeletedFalse(Long memberId);
+
+    List<Driver> findByMemberIdInAndDeletedFalse(Collection<Long> memberIds);
 
     boolean existsByCarNumberAndDeletedFalse(String carNumber);
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostDetailResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostDetailResponse.java
@@ -16,6 +16,7 @@ public class PostDetailResponse {
     private Long id;
     private Long memberId;
     private String nickname;
+    private double driverAverageRating;
     private String title;
     private String departureLocation;
     private Double departureLat;
@@ -35,11 +36,12 @@ public class PostDetailResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static PostDetailResponse from(Post post, String nickname, List<CommentResponse> comments) {
+    public static PostDetailResponse from(Post post, String nickname, double driverAverageRating, List<CommentResponse> comments) {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .memberId(post.getMemberId())
                 .nickname(nickname)
+                .driverAverageRating(driverAverageRating)
                 .title(post.getTitle())
                 .departureLocation(post.getDepartureLocation())
                 .departureLat(post.getDepartureLat())

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostSummaryResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostSummaryResponse.java
@@ -15,6 +15,7 @@ public class PostSummaryResponse {
     private Long id;
     private Long memberId;
     private String nickname;
+    private double driverAverageRating;
     private String title;
     private String departureLocation;
     private String destinationLocation;
@@ -27,11 +28,12 @@ public class PostSummaryResponse {
     private List<TagResponse> tags;
     private LocalDateTime createdAt;
 
-    public static PostSummaryResponse from(Post post, String nickname) {
+    public static PostSummaryResponse from(Post post, String nickname, double driverAverageRating) {
         return PostSummaryResponse.builder()
                 .id(post.getId())
                 .memberId(post.getMemberId())
                 .nickname(nickname)
+                .driverAverageRating(driverAverageRating)
                 .title(post.getTitle())
                 .departureLocation(post.getDepartureLocation())
                 .destinationLocation(post.getDestinationLocation())

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostService.java
@@ -5,6 +5,7 @@ import com.techeer.carpool.domain.application.entity.ApplicationStatus;
 import com.techeer.carpool.domain.application.repository.ApplicationRepository;
 import com.techeer.carpool.domain.comment.dto.CommentResponse;
 import com.techeer.carpool.domain.comment.service.CommentService;
+import com.techeer.carpool.domain.driver.entity.Driver;
 import com.techeer.carpool.domain.driver.repository.DriverRepository;
 import com.techeer.carpool.domain.member.entity.Member;
 import com.techeer.carpool.domain.member.repository.MemberRepository;
@@ -52,7 +53,7 @@ public class PostService {
 
     @Transactional
     public PostDetailResponse createPost(PostCreateRequest request, Long memberId) {
-        driverRepository.findByMemberIdAndDeletedFalse(memberId)
+        Driver driver = driverRepository.findByMemberIdAndDeletedFalse(memberId)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.DRIVER_NOT_FOUND));
 
         List<Tag> tags = resolveTags(request.getTagIds());
@@ -74,7 +75,7 @@ public class PostService {
                 .build();
         Post saved = postRepository.save(post);
         carpoolMetrics.incrementPostCreated();
-        return PostDetailResponse.from(saved, fetchNickname(saved.getMemberId()), List.of());
+        return PostDetailResponse.from(saved, fetchNickname(saved.getMemberId()), driver.getAverageRating(), List.of());
     }
 
     @Transactional(readOnly = true)
@@ -83,8 +84,12 @@ public class PostService {
         Set<Long> memberIds = posts.stream().map(Post::getMemberId).collect(Collectors.toSet());
         Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
                 .collect(Collectors.toMap(Member::getId, Member::getNickname));
+        Map<Long, Double> ratingMap = driverRepository.findByMemberIdInAndDeletedFalse(memberIds).stream()
+                .collect(Collectors.toMap(Driver::getMemberId, Driver::getAverageRating));
         return posts.stream()
-                .map(p -> PostSummaryResponse.from(p, nicknameMap.getOrDefault(p.getMemberId(), "알 수 없음")))
+                .map(p -> PostSummaryResponse.from(p,
+                        nicknameMap.getOrDefault(p.getMemberId(), "알 수 없음"),
+                        ratingMap.getOrDefault(p.getMemberId(), 0.0)))
                 .collect(Collectors.toList());
     }
 
@@ -101,10 +106,13 @@ public class PostService {
         Set<Long> memberIds = postPage.stream().map(Post::getMemberId).collect(Collectors.toSet());
         Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
                 .collect(Collectors.toMap(Member::getId, Member::getNickname));
+        Map<Long, Double> ratingMap = driverRepository.findByMemberIdInAndDeletedFalse(memberIds).stream()
+                .collect(Collectors.toMap(Driver::getMemberId, Driver::getAverageRating));
 
         return postPage.map(p -> PostSummaryResponse.from(
                 postsWithTags.getOrDefault(p.getId(), p),
-                nicknameMap.getOrDefault(p.getMemberId(), "알 수 없음")));
+                nicknameMap.getOrDefault(p.getMemberId(), "알 수 없음"),
+                ratingMap.getOrDefault(p.getMemberId(), 0.0)));
     }
 
     @Transactional(readOnly = true)
@@ -113,8 +121,11 @@ public class PostService {
                 .orElseThrow(() -> new CarpoolException(ErrorCode.POST_NOT_FOUND));
 
         List<CommentResponse> commentResponses = commentService.getCommentsByPostId(id);
+        double rating = driverRepository.findByMemberIdAndDeletedFalse(post.getMemberId())
+                .map(Driver::getAverageRating)
+                .orElse(0.0);
 
-        return PostDetailResponse.from(post, fetchNickname(post.getMemberId()), commentResponses);
+        return PostDetailResponse.from(post, fetchNickname(post.getMemberId()), rating, commentResponses);
     }
 
     @Transactional
@@ -139,7 +150,10 @@ public class PostService {
                 request.getPrice(),
                 tags
         ));
-        return PostDetailResponse.from(post, fetchNickname(post.getMemberId()), List.of());
+        double rating = driverRepository.findByMemberIdAndDeletedFalse(post.getMemberId())
+                .map(Driver::getAverageRating)
+                .orElse(0.0);
+        return PostDetailResponse.from(post, fetchNickname(post.getMemberId()), rating, List.of());
     }
 
     @Transactional


### PR DESCRIPTION
## 관련 이슈
closes #101

## 변경 사항
게시글 목록/단건/생성/수정 응답에 드라이버 평점(`driverAverageRating`) 필드 추가.

**DriverRepository**
- `findByMemberIdInAndDeletedFalse(Collection<Long>)` 추가 — N+1 방지 배치 조회

**PostSummaryResponse / PostDetailResponse**
- `driverAverageRating: double` 필드 추가
- `from()` 시그니처에 `double driverAverageRating` 파라미터 추가

**PostService**
- `getAllPosts()` / `getPagedPosts()`: memberIdIn 배치로 드라이버 한 번에 조회 후 Map으로 O(1) 매핑
- `getPostById()` / `createPost()` / `updatePost()`: 개별 드라이버 조회 후 평점 전달
- 드라이버 미등록 게시글은 `0.0` 반환