### PR TITLE
perf: 서버 시작 시간 개선 (#109)

### DIFF
--- a/.idea/Backend.iml
+++ b/.idea/Backend.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$/sql/seed_data.sql" dialect="PostgreSQL" />
+  </component>
+</project>

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideRepository.java
@@ -18,4 +18,6 @@ public interface RideRepository extends JpaRepository<Ride, Long> {
 
     @Query("SELECT r FROM Ride r JOIN FETCH r.passengers WHERE r.id = :rideId")
     Optional<Ride> findByIdWithPassengers(@Param("rideId") Long rideId);
+
+    Optional<Ride> findFirstByStatus(RideStatus status);
 }

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -66,11 +66,15 @@ public class LocalDataInitializer implements CommandLineRunner {
             allPosts = seedPosts(test, admin, tagMap);
         }
 
+        boolean ridesJustSeeded = false;
         if (rideRepository.count() == 0) {
             seedRides(test, admin, allPosts);
+            ridesJustSeeded = true;
         }
 
-        refreshTimeSensitiveData(allPosts);
+        if (!ridesJustSeeded) {
+            refreshTimeSensitiveData(allPosts);
+        }
 
         log.info("[LocalDataInitializer] 초기 데이터 생성 완료");
     }
@@ -281,9 +285,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                 });
 
         // IN_PROGRESS 운행: startedAt·boardedAt을 지금 기준으로 갱신
-        rideRepository.findAll().stream()
-                .filter(r -> r.getStatus() == RideStatus.IN_PROGRESS)
-                .findFirst()
+        rideRepository.findFirstByStatus(RideStatus.IN_PROGRESS)
                 .ifPresent(r -> {
                     r.refreshStartedAt(LocalDateTime.now().minusMinutes(20));
                     rideRepository.save(r);

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,3 +1,10 @@
+spring:
+  main:
+    lazy-initialization: true
+  jpa:
+    hibernate:
+      ddl-auto: update
+
 jwt:
   secret: local-dev-secret-key-for-testing-only-32chars!!
   access-token-expiration: 900000


### PR DESCRIPTION
## Summary

- `application-local.yml`에 `lazy-initialization: true` 추가 — 시작 시 모든 Bean 즉시 초기화 방지 (30~50% 단축 예상)
- `LocalDataInitializer`: Ride 데이터를 최초 생성하는 시작에서는 `refreshTimeSensitiveData` 스킵 (불필요한 DB 재조회 방지)
- `LocalDataInitializer`: `rideRepository.findAll()` → `findFirstByStatus(IN_PROGRESS)` 로 대체 — 전체 Ride 로딩 제거
- `RideRepository`: `findFirstByStatus(RideStatus)` 메서드 추가

Closes #109

## Test plan

- [ ] 서버 시작 후 로그인 API 정상 동작 확인
- [ ] 서버 시작 후 게시글 목록 API 정상 동작 확인
- [ ] 재시작 시 IN_PROGRESS Ride의 `startedAt`이 현재 시각 기준으로 갱신되는지 확인
- [ ] 최초 실행(DB 비어있는 경우) 테스트 데이터 정상 생성 확인