### PR TITLE
feat: 위치 이력 INSERT 방식으로 변경 (#112)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/ride/controller/RideController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/controller/RideController.java
@@ -77,15 +77,6 @@ public class RideController {
         return ResponseEntity.ok(ApiResponse.of("운행이 종료되었습니다.", rideService.completeRide(rideId, driverId)));
     }
 
-    @PostMapping("/{rideId}/location")
-    public ResponseEntity<ApiResponse<LocationResponse>> updateLocation(
-            @PathVariable Long rideId,
-            @RequestBody @Valid LocationUpdateRequest request,
-            Authentication authentication) {
-        Long driverId = (Long) authentication.getPrincipal();
-        return ResponseEntity.ok(ApiResponse.of("위치가 업데이트되었습니다.", rideService.updateLocation(rideId, request, driverId)));
-    }
-
     @GetMapping("/{rideId}/location")
     public ResponseEntity<ApiResponse<LocationResponse>> getLocation(@PathVariable Long rideId) {
         return ResponseEntity.ok(ApiResponse.of("드라이버 위치 조회 성공", rideService.getLocation(rideId)));

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/dto/LocationResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/dto/LocationResponse.java
@@ -1,8 +1,10 @@
 package com.techeer.carpool.domain.ride.dto;
 
-import com.techeer.carpool.domain.ride.entity.Ride;
+import com.techeer.carpool.domain.ride.entity.RideLocation;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -11,12 +13,17 @@ public class LocationResponse {
     private Long rideId;
     private Double driverLatitude;
     private Double driverLongitude;
+    private LocalDateTime recordedAt;
 
-    public static LocationResponse from(Ride ride) {
+    public static LocationResponse from(Long rideId, RideLocation location) {
+        if (location == null) {
+            return LocationResponse.builder().rideId(rideId).build();
+        }
         return LocationResponse.builder()
-                .rideId(ride.getId())
-                .driverLatitude(ride.getCurrentLatitude())
-                .driverLongitude(ride.getCurrentLongitude())
+                .rideId(rideId)
+                .driverLatitude(location.getLatitude())
+                .driverLongitude(location.getLongitude())
+                .recordedAt(location.getRecordedAt())
                 .build();
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/dto/RideResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/dto/RideResponse.java
@@ -16,8 +16,6 @@ public class RideResponse {
     private Long postId;
     private Long driverId;
     private RideStatus status;
-    private Double currentLatitude;
-    private Double currentLongitude;
     private LocalDateTime startedAt;
     private LocalDateTime completedAt;
 
@@ -39,8 +37,6 @@ public class RideResponse {
                 .postId(ride.getPostId())
                 .driverId(ride.getDriverId())
                 .status(ride.getStatus())
-                .currentLatitude(ride.getCurrentLatitude())
-                .currentLongitude(ride.getCurrentLongitude())
                 .startedAt(ride.getStartedAt())
                 .completedAt(ride.getCompletedAt())
                 .departureTime(post != null ? post.getDepartureTime() : null)

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/entity/Ride.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/entity/Ride.java
@@ -30,9 +30,6 @@ public class Ride extends BaseEntity {
     @Builder.Default             // @Builder 사용 시 기본값 설정 (안 쓰면 null이 됨)
     private RideStatus status = RideStatus.SCHEDULED;  // 운행 상태, 기본값은 "예정"
 
-    private Double currentLatitude;   // 드라이버의 현재 위도
-    private Double currentLongitude;  // 드라이버의 현재 경도
-
     private LocalDateTime startedAt;    // 운행 시작 시각
     private LocalDateTime completedAt;  // 운행 종료 시각
 
@@ -70,12 +67,4 @@ public class Ride extends BaseEntity {
         this.completedAt = LocalDateTime.now();   // 종료 시각 기록
     }
 
-    // 드라이버 위치 업데이트 (출발 30분 전(SCHEDULED) 또는 운행 중(IN_PROGRESS) 허용)
-    public void updateLocation(Double latitude, Double longitude) {
-        if (this.status == RideStatus.COMPLETED) {
-            throw new IllegalStateException("완료된 운행은 위치를 업데이트할 수 없습니다.");
-        }
-        this.currentLatitude = latitude;
-        this.currentLongitude = longitude;
-    }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/entity/RideLocation.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/entity/RideLocation.java
@@ -1,0 +1,41 @@
+package com.techeer.carpool.domain.ride.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ride_locations",
+        indexes = @Index(name = "idx_ride_locations_ride_id_recorded_at", columnList = "ride_id, recorded_at DESC"))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class RideLocation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ride_id", nullable = false)
+    private Long rideId;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    @Column(name = "recorded_at", nullable = false)
+    private LocalDateTime recordedAt;
+
+    public static RideLocation of(Long rideId, Double latitude, Double longitude) {
+        return RideLocation.builder()
+                .rideId(rideId)
+                .latitude(latitude)
+                .longitude(longitude)
+                .recordedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideLocationRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideLocationRepository.java
@@ -1,0 +1,11 @@
+package com.techeer.carpool.domain.ride.repository;
+
+import com.techeer.carpool.domain.ride.entity.RideLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RideLocationRepository extends JpaRepository<RideLocation, Long> {
+
+    Optional<RideLocation> findTopByRideIdOrderByRecordedAtDesc(Long rideId);
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -16,6 +16,8 @@ import com.techeer.carpool.domain.ride.dto.*;
 import com.techeer.carpool.domain.ride.entity.Ride;
 import com.techeer.carpool.domain.ride.entity.RidePassenger;
 import com.techeer.carpool.domain.ride.entity.RideStatus;
+import com.techeer.carpool.domain.ride.entity.RideLocation;
+import com.techeer.carpool.domain.ride.repository.RideLocationRepository;
 import com.techeer.carpool.domain.ride.repository.RidePassengerRepository;
 import com.techeer.carpool.domain.ride.repository.RideRepository;
 import com.techeer.carpool.global.exception.CarpoolException;
@@ -35,6 +37,7 @@ import java.util.stream.Collectors;
 public class RideService {
 
     private final RideRepository rideRepository;
+    private final RideLocationRepository rideLocationRepository;
     private final RidePassengerRepository ridePassengerRepository;
     private final PostRepository postRepository;
     private final DriverRepository driverRepository;
@@ -128,24 +131,17 @@ public class RideService {
     }
 
     @Transactional
-    public LocationResponse updateLocation(Long rideId, LocationUpdateRequest request, Long requesterId) {
-        Ride ride = findRideById(rideId);
-        validateDriver(ride, requesterId);
-        ride.updateLocation(request.getLatitude(), request.getLongitude());
-        carpoolMetrics.incrementLocationUpdated();
-        return LocationResponse.from(ride);
-    }
-
-    @Transactional
     public void updateLocationDirect(Long rideId, Double latitude, Double longitude, Long requesterId) {
         Ride ride = rideRepository.findById(rideId).orElse(null);
         if (ride == null || !ride.getDriverId().equals(requesterId)) return;
         if (ride.getStatus() == RideStatus.COMPLETED) return;
-        ride.updateLocation(latitude, longitude);
+        rideLocationRepository.save(RideLocation.of(rideId, latitude, longitude));
+        carpoolMetrics.incrementLocationUpdated();
     }
 
     public LocationResponse getLocation(Long rideId) {
-        return LocationResponse.from(findRideById(rideId));
+        RideLocation latest = rideLocationRepository.findTopByRideIdOrderByRecordedAtDesc(rideId).orElse(null);
+        return LocationResponse.from(rideId, latest);
     }
 
     public List<RideResponse> getMyRidesAsDriver(Long driverId) {

--- a/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
+++ b/backend/src/main/java/com/techeer/carpool/global/init/LocalDataInitializer.java
@@ -19,6 +19,8 @@ import com.techeer.carpool.domain.ride.entity.Ride;
 import com.techeer.carpool.domain.ride.entity.RidePassenger;
 import com.techeer.carpool.domain.ride.entity.RideStatus;
 import com.techeer.carpool.domain.ride.entity.PassengerStatus;
+import com.techeer.carpool.domain.ride.entity.RideLocation;
+import com.techeer.carpool.domain.ride.repository.RideLocationRepository;
 import com.techeer.carpool.domain.ride.repository.RidePassengerRepository;
 import com.techeer.carpool.domain.ride.repository.RideRepository;
 import com.techeer.carpool.domain.driver.entity.CarColor;
@@ -46,6 +48,7 @@ public class LocalDataInitializer implements CommandLineRunner {
     private final ApplicationRepository applicationRepository;
     private final CommentRepository commentRepository;
     private final RideRepository rideRepository;
+    private final RideLocationRepository rideLocationRepository;
     private final RidePassengerRepository ridePassengerRepository;
     private final ReviewRepository reviewRepository;
     private final PasswordEncoder passwordEncoder;
@@ -284,7 +287,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                     postRepository.save(p);
                 });
 
-        // IN_PROGRESS 운행: startedAt·boardedAt을 지금 기준으로 갱신
+        // IN_PROGRESS 운행: startedAt·boardedAt·위치를 지금 기준으로 갱신
         rideRepository.findFirstByStatus(RideStatus.IN_PROGRESS)
                 .ifPresent(r -> {
                     r.refreshStartedAt(LocalDateTime.now().minusMinutes(20));
@@ -294,6 +297,7 @@ public class LocalDataInitializer implements CommandLineRunner {
                                 rp.refreshBoardedAt(LocalDateTime.now().minusMinutes(18));
                                 ridePassengerRepository.save(rp);
                             });
+                    rideLocationRepository.save(RideLocation.of(r.getId(), 37.5133, 127.0700));
                 });
     }
 
@@ -329,10 +333,9 @@ public class LocalDataInitializer implements CommandLineRunner {
                 .postId(p4.getId())
                 .driverId(admin.getId())
                 .status(RideStatus.IN_PROGRESS)
-                .currentLatitude(37.5133)
-                .currentLongitude(127.0700)
                 .startedAt(LocalDateTime.now().minusMinutes(20))
                 .build());
+        rideLocationRepository.save(RideLocation.of(ride2.getId(), 37.5133, 127.0700));
         ridePassengerRepository.save(RidePassenger.builder()
                 .ride(ride2)
                 .applicationId(appB.getId())


### PR DESCRIPTION
## Summary

- `RideLocation` 엔티티 추가 — `ride_locations` 테이블에 위치 이력을 INSERT 방식으로 저장
- WebSocket으로 위치 수신 시마다 `(ride_id, latitude, longitude, recorded_at)` 새 행 INSERT
- `Ride` 테이블의 `current_latitude`, `current_longitude` 필드 제거 (덮어쓰기 방식 폐기)
- 현재 위치 조회 API(`GET /rides/{id}/location`)는 `ride_locations`에서 최신 1건 반환
- `LocationResponse`에 `recordedAt` 필드 추가

Closes #112

## Test plan

- [ ] WebSocket으로 위치 전송 후 `ride_locations` 테이블에 새 행 INSERT 확인
- [ ] `GET /api/v1/rides/{rideId}/location` 응답에 `recordedAt` 포함 확인
- [ ] 2초 간격 위치 전송 시 매번 새 행이 추가되는지 확인
- [ ] COMPLETED 상태 Ride에 위치 전송 시 INSERT 안 되는지 확인