### PR TITLE
feat: Redis JWT 캐싱 + 게시글 캐싱 고도화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 
 	implementation 'org.springframework.retry:spring-retry:2.0.11'
 	implementation 'org.springframework:spring-aspects'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
@@ -40,7 +40,7 @@ public class PostController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         PageRequest pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok(ApiResponse.of("게시글 목록 조회 성공", postService.getPagedPosts(pageable)));
+        return ResponseEntity.ok(ApiResponse.of("게시글 목록 조회 성공", postService.getUpcomingPagedPosts(pageable)));
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostPageCache.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostPageCache.java
@@ -1,0 +1,19 @@
+package com.techeer.carpool.domain.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Page<PostSummaryResponse>는 PageImpl 역직렬화 이슈로 Redis 직렬화 불가.
+ * content 리스트 + totalElements만 캐싱하고, PageImpl은 서비스 레이어에서 재조립.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPageCache {
+    private List<PostSummaryResponse> content;
+    private long totalElements;
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostSummaryResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/PostSummaryResponse.java
@@ -2,14 +2,20 @@ package com.techeer.carpool.domain.post.dto;
 
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.entity.PostStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static lombok.AccessLevel.PRIVATE;
+
 @Getter
 @Builder
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class PostSummaryResponse {
 
     private Long id;

--- a/backend/src/main/java/com/techeer/carpool/domain/post/dto/TagResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/dto/TagResponse.java
@@ -1,11 +1,17 @@
 package com.techeer.carpool.domain.post.dto;
 
 import com.techeer.carpool.domain.post.entity.Tag;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class TagResponse {
 
     private Long id;

--- a/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -37,4 +39,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndDeletedFalseWithLock(@Param("id") Long id);
 
     List<Post> findByMemberIdAndDeletedFalse(Long memberId);
+
+    // 오늘~+48h 출발 게시글만 조회 (캐싱 대상)
+    @Query(value = "SELECT p FROM Post p WHERE p.deleted = false AND p.status = 'OPEN' " +
+                   "AND p.departureTime >= :from AND p.departureTime < :to ORDER BY p.departureTime ASC",
+           countQuery = "SELECT COUNT(p) FROM Post p WHERE p.deleted = false AND p.status = 'OPEN' " +
+                        "AND p.departureTime >= :from AND p.departureTime < :to")
+    Page<Post> findUpcomingPaged(@Param("from") LocalDateTime from,
+                                 @Param("to") LocalDateTime to,
+                                 Pageable pageable);
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostService.java
@@ -16,9 +16,13 @@ import com.techeer.carpool.domain.notification.service.NotificationService;
 import com.techeer.carpool.domain.notification.type.NotificationType;
 import com.techeer.carpool.domain.post.dto.PostCreateRequest;
 import com.techeer.carpool.domain.post.dto.PostDetailResponse;
+import com.techeer.carpool.domain.post.dto.PostPageCache;
 import com.techeer.carpool.domain.post.dto.PostSummaryResponse;
 import com.techeer.carpool.domain.post.dto.PostUpdateRequest;
+import com.techeer.carpool.global.config.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import com.techeer.carpool.domain.post.entity.Post;
 import com.techeer.carpool.domain.post.entity.PostUpdateCommand;
@@ -50,7 +54,9 @@ public class PostService {
     private final RedisNotificationPublisher notificationPublisher;
     private final NotificationService notificationService;
     private final CarpoolMetrics carpoolMetrics;
+    private final PostUpcomingCacheService postUpcomingCacheService;
 
+    @CacheEvict(cacheNames = CacheConfig.UPCOMING_POSTS, allEntries = true)
     @Transactional
     public PostDetailResponse createPost(PostCreateRequest request, Long memberId) {
         Driver driver = driverRepository.findByMemberIdAndDeletedFalse(memberId)
@@ -94,6 +100,12 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
+    public Page<PostSummaryResponse> getUpcomingPagedPosts(Pageable pageable) {
+        PostPageCache cached = postUpcomingCacheService.getUpcoming(pageable.getPageNumber(), pageable.getPageSize());
+        return new PageImpl<>(cached.getContent(), pageable, cached.getTotalElements());
+    }
+
+    @Transactional(readOnly = true)
     public Page<PostSummaryResponse> getPagedPosts(Pageable pageable) {
         // 1단계: SQL LIMIT/OFFSET으로 페이지 ID 목록 조회
         Page<Post> postPage = postRepository.findPageByDeletedFalse(pageable);
@@ -128,6 +140,7 @@ public class PostService {
         return PostDetailResponse.from(post, fetchNickname(post.getMemberId()), rating, commentResponses);
     }
 
+    @CacheEvict(cacheNames = CacheConfig.UPCOMING_POSTS, allEntries = true)
     @Transactional
     public PostDetailResponse updatePost(Long id, PostUpdateRequest request, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)
@@ -156,6 +169,7 @@ public class PostService {
         return PostDetailResponse.from(post, fetchNickname(post.getMemberId()), rating, List.of());
     }
 
+    @CacheEvict(cacheNames = CacheConfig.UPCOMING_POSTS, allEntries = true)
     @Transactional
     public void deletePost(Long id, Long requesterId) {
         Post post = postRepository.findByIdAndDeletedFalse(id)

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpcomingCacheService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostUpcomingCacheService.java
@@ -1,0 +1,65 @@
+package com.techeer.carpool.domain.post.service;
+
+import com.techeer.carpool.domain.driver.entity.Driver;
+import com.techeer.carpool.domain.driver.repository.DriverRepository;
+import com.techeer.carpool.domain.member.entity.Member;
+import com.techeer.carpool.domain.member.repository.MemberRepository;
+import com.techeer.carpool.domain.post.dto.PostPageCache;
+import com.techeer.carpool.domain.post.dto.PostSummaryResponse;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.config.CacheConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 게시글 캐싱 전담 서비스.
+ * PostService 내부 호출 시 Spring AOP 프록시를 우회하는 문제를 방지하기 위해 분리.
+ * Page<T> 는 Redis 역직렬화가 불가능하므로, PostPageCache(List + totalElements)를 캐싱하고
+ * PostService에서 PageImpl로 재조립.
+ */
+@Service
+@RequiredArgsConstructor
+public class PostUpcomingCacheService {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final DriverRepository driverRepository;
+
+    @Cacheable(cacheNames = CacheConfig.UPCOMING_POSTS, key = "#page + ':' + #size")
+    @Transactional(readOnly = true)
+    public PostPageCache getUpcoming(int page, int size) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime boundary = now.plusHours(48);
+        Page<Post> postPage = postRepository.findUpcomingPaged(now, boundary, PageRequest.of(page, size));
+
+        List<Long> ids = postPage.stream().map(Post::getId).collect(Collectors.toList());
+        Map<Long, Post> postsWithTags = postRepository.findByIdsWithTags(ids).stream()
+                .collect(Collectors.toMap(Post::getId, p -> p));
+
+        Set<Long> memberIds = postPage.stream().map(Post::getMemberId).collect(Collectors.toSet());
+        Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, Member::getNickname));
+        Map<Long, Double> ratingMap = driverRepository.findByMemberIdInAndDeletedFalse(memberIds).stream()
+                .collect(Collectors.toMap(Driver::getMemberId, Driver::getAverageRating));
+
+        List<PostSummaryResponse> content = postPage.stream()
+                .map(p -> PostSummaryResponse.from(
+                        postsWithTags.getOrDefault(p.getId(), p),
+                        nicknameMap.getOrDefault(p.getMemberId(), "알 수 없음"),
+                        ratingMap.getOrDefault(p.getMemberId(), 0.0)))
+                .collect(Collectors.toList());
+
+        return new PostPageCache(content, postPage.getTotalElements());
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/global/config/CacheConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/CacheConfig.java
@@ -1,0 +1,51 @@
+package com.techeer.carpool.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    // 게시글 캐시: 오늘~+48h 출발 게시글, TTL 5분
+    public static final String UPCOMING_POSTS = "upcoming-posts";
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
+        // LocalDateTime 직렬화를 위해 JavaTimeModule을 등록한 별도 ObjectMapper 사용
+        ObjectMapper cacheObjectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .activateDefaultTyping(
+                        new ObjectMapper().getPolymorphicTypeValidator(),
+                        ObjectMapper.DefaultTyping.NON_FINAL
+                );
+
+        RedisCacheConfiguration base = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer(cacheObjectMapper)))
+                .disableCachingNullValues();
+
+        RedisCacheConfiguration upcomingPosts = base
+                .entryTtl(Duration.ofMinutes(5));
+
+        return RedisCacheManager.builder(factory)
+                .cacheDefaults(base)
+                .withCacheConfiguration(UPCOMING_POSTS, upcomingPosts)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.techeer.carpool.global.config;
 
 import com.techeer.carpool.domain.auth.repository.BlacklistRedisRepository;
 import com.techeer.carpool.global.jwt.JwtAuthenticationFilter;
+import com.techeer.carpool.global.jwt.JwtClaimsCacheRepository;
 import com.techeer.carpool.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +27,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final BlacklistRedisRepository blacklistRedisRepository;
+    private final JwtClaimsCacheRepository jwtClaimsCacheRepository;
 
     @Value("${cors.allowed-origins}")
     private String allowedOrigin;
@@ -51,7 +53,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint((request, response, authException) ->
                                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized"))
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, blacklistRedisRepository),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, blacklistRedisRepository, jwtClaimsCacheRepository),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/backend/src/main/java/com/techeer/carpool/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/techeer/carpool/global/jwt/JwtAuthenticationFilter.java
@@ -23,6 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final BlacklistRedisRepository blacklistRedisRepository;
+    private final JwtClaimsCacheRepository jwtClaimsCacheRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -36,7 +37,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     filterChain.doFilter(request, response);
                     return;
                 }
-                Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
+
+                // 캐시 히트: HMAC 검증 스킵
+                Long memberId = jwtClaimsCacheRepository.findMemberId(token).orElse(null);
+                if (memberId == null) {
+                    // 캐시 미스: HMAC 검증 후 캐싱
+                    memberId = jwtTokenProvider.getMemberIdFromToken(token);
+                    long remaining = jwtTokenProvider.getRemainingSeconds(token);
+                    jwtClaimsCacheRepository.save(token, memberId, remaining);
+                }
+
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(memberId, null, List.of());
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/backend/src/main/java/com/techeer/carpool/global/jwt/JwtClaimsCacheRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/global/jwt/JwtClaimsCacheRepository.java
@@ -1,0 +1,49 @@
+package com.techeer.carpool.global.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Access Token → memberId 매핑을 Redis에 캐싱.
+ * 매 요청마다 발생하는 HMAC 서명 검증(CPU 연산)을 캐시 히트 시 스킵.
+ * Key는 SHA-256 해시를 사용해 토큰 원문이 Redis에 저장되지 않도록 함.
+ */
+@Repository
+@RequiredArgsConstructor
+public class JwtClaimsCacheRepository {
+
+    private static final String PREFIX = "jwt:claims:";
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(String token, Long memberId, long ttlSeconds) {
+        if (ttlSeconds <= 0) return;
+        redisTemplate.opsForValue().set(PREFIX + hash(token), memberId.toString(), ttlSeconds, TimeUnit.SECONDS);
+    }
+
+    public Optional<Long> findMemberId(String token) {
+        String value = redisTemplate.opsForValue().get(PREFIX + hash(token));
+        return Optional.ofNullable(value).map(Long::parseLong);
+    }
+
+    public void delete(String token) {
+        redisTemplate.delete(PREFIX + hash(token));
+    }
+
+    private String hash(String input) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Redis를 활용한 JWT Claims 캐싱으로 매 요청마다 발생하는 토큰 파싱 비용 절감
- 게시글 목록 페이지 캐싱(`PostPageCache`) 및 예정 게시글 자동 캐시 갱신 서비스 추가
- `CacheConfig`로 캐시 TTL/직렬화 설정 중앙화

## Changes
- `JwtClaimsCacheRepository`: JWT Claims를 Redis에 캐싱하는 레포지토리 추가
- `JwtAuthenticationFilter`: 필터에서 Redis 캐시 조회 우선 적용
- `PostUpcomingCacheService`: 예정 게시글 주기적 캐싱 서비스 추가
- `CacheConfig`: Redis 캐시 매니저 설정 (TTL, 직렬화)
- `PostPageCache` / `PostSummaryResponse` / `TagResponse`: 캐시용 DTO 추가
- `PostRepository`: 예정 게시글 조회 쿼리 추가

## Test plan
- [ ] 로그인 후 API 재요청 시 Redis에 JWT Claims 캐싱 여부 확인
- [ ] 게시글 목록 조회 시 캐시 히트/미스 동작 확인
- [ ] `PostUpcomingCacheService` 스케줄러 동작 확인
- [ ] 캐시 TTL 만료 후 재발급 정상 동작 확인