### PR TITLE
feat: 운행 중 위치 DB Write-Behind 캐싱 도입 (#74)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/ride/dto/LocationResponse.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/dto/LocationResponse.java
@@ -26,4 +26,13 @@ public class LocationResponse {
                 .recordedAt(location.getRecordedAt())
                 .build();
     }
+
+    public static LocationResponse fromEntry(Long rideId, RideLocationEntry entry) {
+        return LocationResponse.builder()
+                .rideId(rideId)
+                .driverLatitude(entry.getLatitude())
+                .driverLongitude(entry.getLongitude())
+                .recordedAt(entry.getRecordedAt())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/dto/RideLocationEntry.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/dto/RideLocationEntry.java
@@ -1,0 +1,25 @@
+package com.techeer.carpool.domain.ride.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class RideLocationEntry {
+
+    private final Double latitude;
+    private final Double longitude;
+    private final LocalDateTime recordedAt;
+
+    @JsonCreator
+    public RideLocationEntry(
+            @JsonProperty("latitude") Double latitude,
+            @JsonProperty("longitude") Double longitude,
+            @JsonProperty("recordedAt") LocalDateTime recordedAt) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.recordedAt = recordedAt;
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/entity/RideLocation.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/entity/RideLocation.java
@@ -38,4 +38,13 @@ public class RideLocation {
                 .recordedAt(LocalDateTime.now())
                 .build();
     }
+
+    public static RideLocation of(Long rideId, Double latitude, Double longitude, LocalDateTime recordedAt) {
+        return RideLocation.builder()
+                .rideId(rideId)
+                .latitude(latitude)
+                .longitude(longitude)
+                .recordedAt(recordedAt)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideLocationRedisRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideLocationRedisRepository.java
@@ -1,0 +1,72 @@
+package com.techeer.carpool.domain.ride.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.carpool.domain.ride.dto.RideLocationEntry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class RideLocationRedisRepository {
+
+    private static final String KEY_PREFIX = "ride:route:";
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void push(Long rideId, Double latitude, Double longitude) {
+        String key = key(rideId);
+        String value = serialize(new RideLocationEntry(latitude, longitude, LocalDateTime.now()));
+        stringRedisTemplate.opsForList().rightPush(key, value);
+        stringRedisTemplate.expire(key, TTL);
+    }
+
+    public RideLocationEntry getLatest(Long rideId) {
+        String value = stringRedisTemplate.opsForList().index(key(rideId), -1);
+        if (value == null) return null;
+        return deserialize(value);
+    }
+
+    public List<RideLocationEntry> getAll(Long rideId) {
+        List<String> values = stringRedisTemplate.opsForList().range(key(rideId), 0, -1);
+        if (values == null) return Collections.emptyList();
+        return values.stream()
+                .map(this::deserialize)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    public void delete(Long rideId) {
+        stringRedisTemplate.delete(key(rideId));
+    }
+
+    private String key(Long rideId) {
+        return KEY_PREFIX + rideId;
+    }
+
+    private String serialize(RideLocationEntry entry) {
+        try {
+            return objectMapper.writeValueAsString(entry);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("RideLocationEntry 직렬화 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private RideLocationEntry deserialize(String value) {
+        try {
+            return objectMapper.readValue(value, RideLocationEntry.class);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -17,9 +17,12 @@ import com.techeer.carpool.domain.ride.entity.Ride;
 import com.techeer.carpool.domain.ride.entity.RidePassenger;
 import com.techeer.carpool.domain.ride.entity.RideStatus;
 import com.techeer.carpool.domain.ride.entity.RideLocation;
+import com.techeer.carpool.domain.ride.repository.RideLocationRedisRepository;
 import com.techeer.carpool.domain.ride.repository.RideLocationRepository;
 import com.techeer.carpool.domain.ride.repository.RidePassengerRepository;
 import com.techeer.carpool.domain.ride.repository.RideRepository;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.metrics.CarpoolMetrics;
@@ -38,6 +41,7 @@ public class RideService {
 
     private final RideRepository rideRepository;
     private final RideLocationRepository rideLocationRepository;
+    private final RideLocationRedisRepository rideLocationRedisRepository;
     private final RidePassengerRepository ridePassengerRepository;
     private final PostRepository postRepository;
     private final DriverRepository driverRepository;
@@ -114,6 +118,22 @@ public class RideService {
         ride.complete();
         carpoolMetrics.incrementRideCompleted();
 
+        // Redis List → DB 배치 INSERT (Write-Behind flush)
+        List<RideLocationEntry> entries = rideLocationRedisRepository.getAll(rideId);
+        if (!entries.isEmpty()) {
+            List<RideLocation> locations = entries.stream()
+                    .map(e -> RideLocation.of(rideId, e.getLatitude(), e.getLongitude(), e.getRecordedAt()))
+                    .collect(Collectors.toList());
+            rideLocationRepository.saveAll(locations);
+        }
+        // DB 커밋 성공 후 Redis 키 삭제 (커밋 전 삭제 시 데이터 유실 방지)
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                rideLocationRedisRepository.delete(rideId);
+            }
+        });
+
         List<Long> passengerIds = ride.getPassengers().stream()
                 .map(RidePassenger::getPassengerId)
                 .collect(Collectors.toList());
@@ -130,16 +150,21 @@ public class RideService {
         return RideResponse.from(ride, post);
     }
 
-    @Transactional
     public void updateLocationDirect(Long rideId, Double latitude, Double longitude, Long requesterId) {
         Ride ride = rideRepository.findById(rideId).orElse(null);
         if (ride == null || !ride.getDriverId().equals(requesterId)) return;
         if (ride.getStatus() == RideStatus.COMPLETED) return;
-        rideLocationRepository.save(RideLocation.of(rideId, latitude, longitude));
+        // DB 직접 저장 대신 Redis List에 append (Write-Behind)
+        rideLocationRedisRepository.push(rideId, latitude, longitude);
         carpoolMetrics.incrementLocationUpdated();
     }
 
     public LocationResponse getLocation(Long rideId) {
+        // 운행 중: Redis에서 최신 위치 조회, 없으면 DB fallback
+        RideLocationEntry entry = rideLocationRedisRepository.getLatest(rideId);
+        if (entry != null) {
+            return LocationResponse.fromEntry(rideId, entry);
+        }
         RideLocation latest = rideLocationRepository.findTopByRideIdOrderByRecordedAtDesc(rideId).orElse(null);
         return LocationResponse.from(rideId, latest);
     }


### PR DESCRIPTION
## 개요

운행 중 매 위치 수신마다 DB에 직접 INSERT하던 구조를 Redis Write-Behind 패턴으로 변경.
운행 종료 시 Redis → DB 일괄 flush하여 운행 중 HikariCP 커넥션 점유 제거.

## 변경 사항

- `RideLocationEntry.java` (신규): Redis 직렬화용 위치 데이터 DTO
- `RideLocationRedisRepository.java` (신규): Redis List 기반 위치 버퍼 (RPUSH / LINDEX / LRANGE / DEL)
- `RideService.updateLocationDirect()`: DB INSERT → `rideLocationRedisRepository.push()` 로 변경
- `RideService.completeRide()`: 종료 시 Redis 전체 flush → DB 배치 INSERT, `afterCommit()` 훅으로 Redis 키 삭제
- `RideService.getLocation()`: Redis 최신값 우선 조회, 없으면 DB fallback
- `RideLocation.of()`: `recordedAt` 파라미터 오버로드 추가
- `LocationResponse.fromEntry()`: `RideLocationEntry` 변환 팩토리 추가

## 테스트 결과 (SCALE=1000, 06_ride_location_load.js)

| 지표 | Write-Behind 전 | Write-Behind 후 |
|------|---------------|----------------|
| INSERT 건수 | 86,458 | **95,272 (+10%)** |
| INSERT 속도 | 485/s | **521/s (+7%)** |
| 중단 이터레이션 | **442건** | **79건 (-82%)** |
| 위치 전송 에러 | 0건 | 0건 |

Closes #74