### PR TITLE
fix: PostCloseService 게시글 마감 시 캐시 무효화 누락

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCloseService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostCloseService.java
@@ -16,10 +16,12 @@ import com.techeer.carpool.domain.ride.entity.Ride;
 import com.techeer.carpool.domain.ride.entity.RidePassenger;
 import com.techeer.carpool.domain.ride.repository.RidePassengerRepository;
 import com.techeer.carpool.domain.ride.repository.RideRepository;
+import com.techeer.carpool.global.config.CacheConfig;
 import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.metrics.CarpoolMetrics;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +43,7 @@ public class PostCloseService {
     private final CarpoolMetrics carpoolMetrics;
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.UPCOMING_POSTS, allEntries = true)
     public void closePost(Long postId, Long requesterId) {
         driverRepository.findByMemberIdAndDeletedFalse(requesterId)
                 .orElseThrow(() -> new CarpoolException(ErrorCode.DRIVER_NOT_FOUND));


### PR DESCRIPTION
## Summary
- `PostCloseService.closePost()`에 `@CacheEvict` 누락으로 게시글 마감 후 5분간 `upcoming-posts` 캐시가 stale 상태 유지되는 버그 수정
- `@CacheEvict(cacheNames = CacheConfig.UPCOMING_POSTS, allEntries = true)` 추가

## Root Cause
`PostService`의 create/update/delete에는 모두 `@CacheEvict`가 있었지만, 별도 서비스 클래스인 `PostCloseService.closePost()`에는 누락됨.

Closes #125

## Test plan
- [ ] 게시글 마감 후 `/api/v1/posts` 조회 시 마감된 게시글 즉시 제외 확인
- [ ] 캐시 TTL 5분 내에도 마감 결과 반영 확인