### PR TITLE
feat: 게시글 자동 마감 스케줄러 + 출발 임박 드라이버 알림

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/CarpoolApplication.java
+++ b/backend/src/main/java/com/techeer/carpool/CarpoolApplication.java
@@ -3,9 +3,11 @@ package com.techeer.carpool;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableRetry
+@EnableScheduling
 public class
 CarpoolApplication {
 

--- a/backend/src/main/java/com/techeer/carpool/domain/notification/entity/Notification.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/notification/entity/Notification.java
@@ -110,6 +110,15 @@ public class Notification {
                 .build();
     }
 
+    public static Notification ofDepartureApproaching(Long receiverId, Long postId) {
+        return Notification.builder()
+                .type(NotificationType.DEPARTURE_APPROACHING)
+                .receiverId(receiverId)
+                .referenceId(postId)
+                .message("1시간 후 출발 예정입니다. 카풀을 마감해 주세요.")
+                .build();
+    }
+
     public void markAsRead() {
         if (this.readAt == null) {
             this.readAt = LocalDateTime.now();

--- a/backend/src/main/java/com/techeer/carpool/domain/notification/type/NotificationType.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/notification/type/NotificationType.java
@@ -6,5 +6,6 @@ public enum NotificationType {
     APPLICATION_REJECTED,  // 신청 거절 → 신청자
     RIDE_STARTED,          // 운행 시작 → 탑승 확정자 전원
     RIDE_ENDED,            // 운행 종료 → 탑승 확정자 전원
-    POST_CANCELLED         // 게시글 삭제 → ACCEPTED 신청자 전원
+    POST_CANCELLED,        // 게시글 삭제 → ACCEPTED 신청자 전원
+    DEPARTURE_APPROACHING  // 출발 1시간 전 임박 → 드라이버
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
@@ -31,6 +31,15 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findByIdAndDeletedFalse(Long id);
 
+    // 출발 시간이 지났지만 아직 OPEN 상태인 게시글 (자동 마감 대상)
+    @Query("SELECT p FROM Post p WHERE p.deleted = false AND p.status = 'OPEN' AND p.departureTime <= :now")
+    List<Post> findExpiredOpenPosts(@Param("now") LocalDateTime now);
+
+    // 출발 N분 전 게시글 (드라이버 임박 알림 대상)
+    @Query("SELECT p FROM Post p WHERE p.deleted = false AND p.status = 'OPEN' " +
+           "AND p.departureTime >= :from AND p.departureTime < :to")
+    List<Post> findApproachingOpenPosts(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.tags WHERE p.id = :id AND p.deleted = false")
     Optional<Post> findByIdAndDeletedFalseWithTags(@Param("id") Long id);
 

--- a/backend/src/main/java/com/techeer/carpool/domain/post/scheduler/PostScheduler.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/scheduler/PostScheduler.java
@@ -1,0 +1,92 @@
+package com.techeer.carpool.domain.post.scheduler;
+
+import com.techeer.carpool.domain.notification.dto.NotificationPayload;
+import com.techeer.carpool.domain.notification.entity.Notification;
+import com.techeer.carpool.domain.notification.publisher.RedisNotificationPublisher;
+import com.techeer.carpool.domain.notification.service.NotificationService;
+import com.techeer.carpool.domain.notification.type.NotificationType;
+import com.techeer.carpool.domain.post.entity.Post;
+import com.techeer.carpool.domain.post.repository.PostRepository;
+import com.techeer.carpool.global.config.CacheConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostScheduler {
+
+    private static final String DEPARTURE_NOTIF_KEY = "departure_notif:";
+    private static final int APPROACHING_MINUTES = 60;
+
+    private final PostRepository postRepository;
+    private final NotificationService notificationService;
+    private final RedisNotificationPublisher notificationPublisher;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final CacheManager cacheManager;
+
+    /**
+     * 출발 시간이 지난 OPEN 게시글을 1분마다 자동 마감.
+     */
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional
+    public void autoCloseExpiredPosts() {
+        List<Post> expired = postRepository.findExpiredOpenPosts(LocalDateTime.now());
+        if (expired.isEmpty()) return;
+
+        expired.forEach(Post::close);
+        evictUpcomingCache();
+        log.info("자동 마감 완료: {}건", expired.size());
+    }
+
+    /**
+     * 출발 1시간 전 드라이버에게 알림을 5분마다 체크.
+     * Redis key로 중복 발송 방지.
+     */
+    @Scheduled(fixedDelay = 300_000)
+    @Transactional
+    public void notifyApproachingDeparture() {
+        LocalDateTime from = LocalDateTime.now().plusMinutes(APPROACHING_MINUTES - 5);
+        LocalDateTime to   = LocalDateTime.now().plusMinutes(APPROACHING_MINUTES + 5);
+
+        List<Post> approaching = postRepository.findApproachingOpenPosts(from, to);
+        List<Post> unnotified = approaching.stream()
+                .filter(p -> Boolean.FALSE.equals(
+                        stringRedisTemplate.hasKey(DEPARTURE_NOTIF_KEY + p.getId())))
+                .collect(Collectors.toList());
+
+        if (unnotified.isEmpty()) return;
+
+        notificationService.saveAll(unnotified.stream()
+                .map(p -> Notification.ofDepartureApproaching(p.getMemberId(), p.getId()))
+                .collect(Collectors.toList()));
+
+        unnotified.forEach(p -> {
+            notificationPublisher.publish(p.getMemberId(), NotificationPayload.builder()
+                    .type(NotificationType.DEPARTURE_APPROACHING)
+                    .message("1시간 후 출발 예정입니다. 카풀을 마감해 주세요.")
+                    .data(Map.of("postId", p.getId()))
+                    .build());
+            stringRedisTemplate.opsForValue()
+                    .set(DEPARTURE_NOTIF_KEY + p.getId(), "1", Duration.ofHours(3));
+        });
+
+        log.info("출발 임박 알림 발송: {}건", unnotified.size());
+    }
+
+    private void evictUpcomingCache() {
+        var cache = cacheManager.getCache(CacheConfig.UPCOMING_POSTS);
+        if (cache != null) cache.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- 출발 시간이 지난 OPEN 게시글을 1분마다 자동 마감 (Issue #111)
- 출발 1시간 전 드라이버에게 임박 알림 발송 (Issue #91)

## 구현 내용
| 컴포넌트 | 내용 |
|---|---|
| `PostScheduler.autoCloseExpiredPosts()` | 1분 주기, `departureTime <= now` OPEN 게시글 일괄 마감 + 캐시 무효화 |
| `PostScheduler.notifyApproachingDeparture()` | 5분 주기, 출발 ±5분 윈도우 탐지, Redis key로 중복 발송 방지 |
| `NotificationType.DEPARTURE_APPROACHING` | 신규 알림 타입 |
| `PostRepository.findExpiredOpenPosts()` | 만료 게시글 조회 |
| `PostRepository.findApproachingOpenPosts()` | 임박 게시글 조회 |

## 중복 발송 방지
`departure_notif:{postId}` Redis key (TTL 3h)를 이용해 동일 게시글에 알림이 한 번만 발송되도록 보장.

Closes #111
Closes #91

## Test plan
- [ ] 출발 시간 경과 OPEN 게시글이 1분 이내 자동 CLOSED 상태로 변경 확인
- [ ] 출발 1시간 전 드라이버에게 알림 수신 확인
- [ ] 동일 게시글 중복 알림 미발송 확인