### PR TITLE
feat: 게시글 날짜/위치 기반 서버사이드 필터링

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/controller/PostController.java
@@ -11,11 +11,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -38,8 +40,17 @@ public class PostController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<PostSummaryResponse>>> getAllPosts(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size) {
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(required = false) Double lat,
+            @RequestParam(required = false) Double lng,
+            @RequestParam(required = false) Double radiusKm) {
         PageRequest pageable = PageRequest.of(page, size);
+        boolean hasFilter = date != null || (lat != null && lng != null);
+        if (hasFilter) {
+            return ResponseEntity.ok(ApiResponse.of("게시글 목록 조회 성공",
+                    postService.getFilteredPosts(pageable, date, lat, lng, radiusKm)));
+        }
         return ResponseEntity.ok(ApiResponse.of("게시글 목록 조회 성공", postService.getUpcomingPagedPosts(pageable)));
     }
 

--- a/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/repository/PostRepository.java
@@ -57,4 +57,31 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findUpcomingPaged(@Param("from") LocalDateTime from,
                                  @Param("to") LocalDateTime to,
                                  Pageable pageable);
+
+    // 날짜/위치(바운딩 박스) 기반 필터링 (선택적 파라미터)
+    @Query(value = "SELECT p FROM Post p WHERE p.deleted = false AND p.status = 'OPEN' " +
+                   "AND p.departureTime >= CURRENT_TIMESTAMP " +
+                   "AND (:fromDate IS NULL OR p.departureTime >= :fromDate) " +
+                   "AND (:toDate IS NULL OR p.departureTime < :toDate) " +
+                   "AND (:minLat IS NULL OR p.departureLat >= :minLat) " +
+                   "AND (:maxLat IS NULL OR p.departureLat <= :maxLat) " +
+                   "AND (:minLng IS NULL OR p.departureLng >= :minLng) " +
+                   "AND (:maxLng IS NULL OR p.departureLng <= :maxLng) " +
+                   "ORDER BY p.departureTime ASC",
+           countQuery = "SELECT COUNT(p) FROM Post p WHERE p.deleted = false AND p.status = 'OPEN' " +
+                        "AND p.departureTime >= CURRENT_TIMESTAMP " +
+                        "AND (:fromDate IS NULL OR p.departureTime >= :fromDate) " +
+                        "AND (:toDate IS NULL OR p.departureTime < :toDate) " +
+                        "AND (:minLat IS NULL OR p.departureLat >= :minLat) " +
+                        "AND (:maxLat IS NULL OR p.departureLat <= :maxLat) " +
+                        "AND (:minLng IS NULL OR p.departureLng >= :minLng) " +
+                        "AND (:maxLng IS NULL OR p.departureLng <= :maxLng)")
+    Page<Post> findFiltered(
+            @Param("fromDate") LocalDateTime fromDate,
+            @Param("toDate") LocalDateTime toDate,
+            @Param("minLat") Double minLat,
+            @Param("maxLat") Double maxLat,
+            @Param("minLng") Double minLng,
+            @Param("maxLng") Double maxLng,
+            Pageable pageable);
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/post/service/PostService.java
@@ -36,6 +36,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -112,6 +114,46 @@ public class PostService {
         List<Long> ids = postPage.stream().map(Post::getId).collect(Collectors.toList());
 
         // 2단계: 해당 ID들만 tags 배치 로드 (N+1 방지)
+        Map<Long, Post> postsWithTags = postRepository.findByIdsWithTags(ids).stream()
+                .collect(Collectors.toMap(Post::getId, p -> p));
+
+        Set<Long> memberIds = postPage.stream().map(Post::getMemberId).collect(Collectors.toSet());
+        Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, Member::getNickname));
+        Map<Long, Double> ratingMap = driverRepository.findByMemberIdInAndDeletedFalse(memberIds).stream()
+                .collect(Collectors.toMap(Driver::getMemberId, Driver::getAverageRating));
+
+        return postPage.map(p -> PostSummaryResponse.from(
+                postsWithTags.getOrDefault(p.getId(), p),
+                nicknameMap.getOrDefault(p.getMemberId(), "알 수 없음"),
+                ratingMap.getOrDefault(p.getMemberId(), 0.0)));
+    }
+
+    /**
+     * 날짜/위치 필터 기반 게시글 조회. 캐시 미사용.
+     * lat/lng/radiusKm 제공 시 바운딩 박스로 근접 게시글만 반환.
+     */
+    @Transactional(readOnly = true)
+    public Page<PostSummaryResponse> getFilteredPosts(
+            Pageable pageable, LocalDate date, Double lat, Double lng, Double radiusKm) {
+
+        LocalDateTime fromDate = date != null ? date.atStartOfDay() : null;
+        LocalDateTime toDate   = date != null ? date.plusDays(1).atStartOfDay() : null;
+
+        Double minLat = null, maxLat = null, minLng = null, maxLng = null;
+        if (lat != null && lng != null) {
+            double radius = radiusKm != null ? radiusKm : 5.0;
+            double latDelta = radius / 111.0;
+            double lngDelta = radius / (111.0 * Math.cos(Math.toRadians(lat)));
+            minLat = lat - latDelta;
+            maxLat = lat + latDelta;
+            minLng = lng - lngDelta;
+            maxLng = lng + lngDelta;
+        }
+
+        Page<Post> postPage = postRepository.findFiltered(
+                fromDate, toDate, minLat, maxLat, minLng, maxLng, pageable);
+        List<Long> ids = postPage.stream().map(Post::getId).collect(Collectors.toList());
         Map<Long, Post> postsWithTags = postRepository.findByIdsWithTags(ids).stream()
                 .collect(Collectors.toMap(Post::getId, p -> p));
 


### PR DESCRIPTION
## Summary
`GET /api/v1/posts`에 날짜 및 위치 기반 필터 파라미터를 추가합니다.

## API 변경
```
GET /api/v1/posts?date=2026-06-01&lat=37.5&lng=127.0&radiusKm=10
```

| 파라미터 | 타입 | 설명 |
|---|---|---|
| `date` | LocalDate (ISO) | 출발 날짜 필터 |
| `lat`, `lng` | Double | 출발지 근접 검색 중심 좌표 |
| `radiusKm` | Double | 검색 반경 (기본 5km) |

## 구현
- **필터 없음** → 기존 Redis 캐시 경로 그대로 유지 (성능 영향 없음)
- **필터 있음** → DB 직접 조회 (`PostRepository.findFiltered()`)
- 위치 필터: 위도/경도 기반 바운딩 박스(±latDelta, ±lngDelta) 근사 계산 후 JPQL WHERE 절 적용
- 태그 N+1 방지: 기존 `findByIdsWithTags()` 배치 로드 방식 재사용

Closes #90

## Test plan
- [ ] `GET /api/v1/posts?date=2026-06-01` → 해당 날짜 출발 게시글만 반환 확인
- [ ] `GET /api/v1/posts?lat=37.5&lng=127.0&radiusKm=5` → 5km 반경 게시글만 반환 확인
- [ ] 파라미터 없을 때 기존 캐시 동작 유지 확인