### PR TITLE
fix: 동시성 안전성 - 좌석 초과 / 중복 신청 / 평점 Race Condition 수정

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationCreateService.java
@@ -17,6 +17,7 @@ import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.metrics.CarpoolMetrics;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -64,11 +65,19 @@ public class ApplicationCreateService {
                 .build();
 
         if (post.isAutoAccept()) {
+            if (post.isFull()) {
+                throw new CarpoolException(ErrorCode.APPLICATION_POST_FULL);
+            }
             application.accept();
             post.incrementPassengers();
         }
 
-        Application saved = applicationRepository.save(application);
+        Application saved;
+        try {
+            saved = applicationRepository.save(application);
+        } catch (DataIntegrityViolationException e) {
+            throw new CarpoolException(ErrorCode.APPLICATION_DUPLICATE);
+        }
         carpoolMetrics.incrementApplicationSubmitted();
 
         String nickname = memberRepository.findById(applicantId)

--- a/backend/src/main/java/com/techeer/carpool/domain/driver/entity/Driver.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/driver/entity/Driver.java
@@ -20,6 +20,9 @@ public class Driver extends SoftDeletableEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long driverId;
 
+    @Version
+    private Long version;
+
     @Column(nullable = false)
     private Long memberId;
 

--- a/backend/src/main/java/com/techeer/carpool/domain/driver/repository/DriverRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/driver/repository/DriverRepository.java
@@ -1,7 +1,11 @@
 package com.techeer.carpool.domain.driver.repository;
 
 import com.techeer.carpool.domain.driver.entity.Driver;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -10,6 +14,10 @@ import java.util.Optional;
 public interface DriverRepository extends JpaRepository<Driver, Long> {
 
     Optional<Driver> findByMemberIdAndDeletedFalse(Long memberId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT d FROM Driver d WHERE d.memberId = :memberId AND d.deleted = false")
+    Optional<Driver> findByMemberIdAndDeletedFalseWithLock(@Param("memberId") Long memberId);
 
     List<Driver> findByMemberIdInAndDeletedFalse(Collection<Long> memberIds);
 

--- a/backend/src/main/java/com/techeer/carpool/domain/review/service/ReviewCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/service/ReviewCreateService.java
@@ -13,6 +13,9 @@ import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.metrics.CarpoolMetrics;
 import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +28,11 @@ public class ReviewCreateService {
     private final DriverRepository driverRepository;
     private final CarpoolMetrics carpoolMetrics;
 
+    @Retryable(
+            retryFor = ObjectOptimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 50, multiplier = 1.5, random = true)
+    )
     @Transactional
     public ReviewResponse createReview(Long rideId, ReviewCreateRequest request, Long reviewerId) {
         Ride ride = rideRepository.findById(rideId)
@@ -52,7 +60,7 @@ public class ReviewCreateService {
                 .comment(request.getComment())
                 .build());
 
-        Driver driver = driverRepository.findByMemberIdAndDeletedFalse(ride.getDriverId())
+        Driver driver = driverRepository.findByMemberIdAndDeletedFalseWithLock(ride.getDriverId())
                 .orElseThrow(() -> new CarpoolException(ErrorCode.DRIVER_NOT_FOUND));
         driver.addRating(request.getRating());
         carpoolMetrics.incrementReviewCreated();


### PR DESCRIPTION
## 관련 이슈
closes #129

## 변경 요약

동시 요청 시 데이터 정합성이 깨질 수 있는 Race Condition 3건을 수정합니다.

---

### 1. Post 좌석 `isFull()` 방어 검증 추가 (`ApplicationCreateService`)

**문제:** `autoAccept = true`일 때 `post.getStatus() == CLOSED`만 체크하고 `post.isFull()` 검증을 누락. Optimistic Lock retry 이전에 `currentPassengers`가 `maxPassengers`를 초과하는 엣지 케이스 존재.

**수정:**
```java
if (post.isAutoAccept()) {
    if (post.isFull()) {                         // 추가된 방어 검증
        throw new CarpoolException(ErrorCode.APPLICATION_POST_FULL);
    }
    application.accept();
    post.incrementPassengers();
}
```

---

### 2. 중복 신청 Race Condition → 500 에러 방지 (`ApplicationCreateService`)

**문제:** `existsByPostIdAndApplicantId()` 체크와 `save()` 사이의 Gap에서 동시 요청이 들어오면 DB UniqueConstraint가 `DataIntegrityViolationException`을 던지고 500으로 응답.

**수정:**
```java
try {
    saved = applicationRepository.save(application);
} catch (DataIntegrityViolationException e) {
    throw new CarpoolException(ErrorCode.APPLICATION_DUPLICATE);  // 409로 변환
}
```

---

### 3. Driver 평점 Lost Update 방지 (`Driver`, `DriverRepository`, `ReviewCreateService`)

**문제:** `Driver` 엔티티에 `@Version`이 없어 동시 리뷰 등록 시 `totalRatingSum` / `reviewCount` 증가가 덮어써지는 Lost Update 발생 가능.

**수정:**
- `Driver`에 `@Version private Long version` 추가
- `DriverRepository`에 `@Lock(OPTIMISTIC)` 쿼리 메서드 추가
- `ReviewCreateService`에 `@Retryable(ObjectOptimisticLockingFailureException, maxAttempts=3)` 추가
- Lock 조회(`findByMemberIdAndDeletedFalseWithLock`)로 교체

---

## 테스트 체크리스트

- [ ] autoAccept 게시글에 동시 신청 시 정원 초과 없음
- [ ] 동일 사용자가 같은 게시글에 동시 신청 시 409 반환 (500 아님)
- [ ] 같은 운행에 여러 리뷰 동시 등록 시 평점 계산 정확