### PR TITLE
fix: IDOR 보안 + 리뷰 중복 500 + ApplicationStatus 재시도 누락 + RideService N+1

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationStatusService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/application/service/ApplicationStatusService.java
@@ -17,6 +17,9 @@ import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.metrics.CarpoolMetrics;
 import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +36,11 @@ public class ApplicationStatusService {
     private final NotificationService notificationService;
     private final CarpoolMetrics carpoolMetrics;
 
+    @Retryable(
+            retryFor = ObjectOptimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 50, multiplier = 1.5, random = true)
+    )
     @Transactional
     public ApplicationResponse accept(Long applicationId, Long requesterId) {
         Application application = findPending(applicationId);

--- a/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/member/controller/MemberController.java
@@ -5,6 +5,8 @@ import com.techeer.carpool.domain.member.dto.ProfileUpdateRequest;
 import com.techeer.carpool.domain.member.service.MemberProfileService;
 import com.techeer.carpool.domain.member.service.MemberWithdrawService;
 import com.techeer.carpool.global.common.ApiResponse;
+import com.techeer.carpool.global.exception.CarpoolException;
+import com.techeer.carpool.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +24,13 @@ public class MemberController {
     private final MemberWithdrawService memberWithdrawService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<ProfileResponse>> getProfileById(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<ProfileResponse>> getProfileById(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long callerId = (Long) authentication.getPrincipal();
+        if (!callerId.equals(id)) {
+            throw new CarpoolException(ErrorCode.MEMBER_FORBIDDEN);
+        }
         ProfileResponse profile = memberProfileService.getProfile(id);
         return ResponseEntity.ok(ApiResponse.of("프로필을 조회했습니다.", profile));
     }

--- a/backend/src/main/java/com/techeer/carpool/domain/review/service/ReviewCreateService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/review/service/ReviewCreateService.java
@@ -13,6 +13,7 @@ import com.techeer.carpool.global.exception.CarpoolException;
 import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.metrics.CarpoolMetrics;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -52,13 +53,18 @@ public class ReviewCreateService {
             throw new CarpoolException(ErrorCode.REVIEW_ALREADY_EXISTS);
         }
 
-        Review review = reviewRepository.save(Review.builder()
-                .rideId(rideId)
-                .reviewerId(reviewerId)
-                .driverId(ride.getDriverId())
-                .rating(request.getRating())
-                .comment(request.getComment())
-                .build());
+        Review review;
+        try {
+            review = reviewRepository.save(Review.builder()
+                    .rideId(rideId)
+                    .reviewerId(reviewerId)
+                    .driverId(ride.getDriverId())
+                    .rating(request.getRating())
+                    .comment(request.getComment())
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            throw new CarpoolException(ErrorCode.REVIEW_ALREADY_EXISTS);
+        }
 
         Driver driver = driverRepository.findByMemberIdAndDeletedFalseWithLock(ride.getDriverId())
                 .orElseThrow(() -> new CarpoolException(ErrorCode.DRIVER_NOT_FOUND));

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RidePassengerRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RidePassengerRepository.java
@@ -17,6 +17,9 @@ public interface RidePassengerRepository extends JpaRepository<RidePassenger, Lo
 
     List<RidePassenger> findAllByPassengerIdOrderByCreatedAtDesc(Long passengerId);
 
+    @Query("SELECT rp FROM RidePassenger rp JOIN FETCH rp.ride WHERE rp.passengerId = :passengerId ORDER BY rp.createdAt DESC")
+    List<RidePassenger> findAllByPassengerIdWithRideOrderByCreatedAtDesc(@Param("passengerId") Long passengerId);
+
     @Query("SELECT rp FROM RidePassenger rp JOIN FETCH rp.ride WHERE rp.passengerId = :passengerId AND rp.ride.status = :status ORDER BY rp.ride.completedAt DESC")
     List<RidePassenger> findByPassengerIdAndRideStatus(@Param("passengerId") Long passengerId, @Param("status") RideStatus status);
 }

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -170,23 +171,25 @@ public class RideService {
     }
 
     public List<RideResponse> getMyRidesAsDriver(Long driverId) {
-        return rideRepository.findAllByDriverIdOrderByCreatedAtDesc(driverId)
-                .stream()
-                .map(ride -> {
-                    Post post = postRepository.findByIdAndDeletedFalse(ride.getPostId()).orElse(null);
-                    return RideResponse.from(ride, post);
-                })
+        List<Ride> rides = rideRepository.findAllByDriverIdOrderByCreatedAtDesc(driverId);
+        Set<Long> postIds = rides.stream().map(Ride::getPostId).collect(Collectors.toSet());
+        Map<Long, Post> postMap = postRepository.findAllById(postIds).stream()
+                .collect(Collectors.toMap(Post::getId, p -> p));
+        return rides.stream()
+                .map(ride -> RideResponse.from(ride, postMap.get(ride.getPostId())))
                 .collect(Collectors.toList());
     }
 
     public List<RideResponse> getMyRidesAsPassenger(Long passengerId) {
-        return ridePassengerRepository.findAllByPassengerIdOrderByCreatedAtDesc(passengerId)
-                .stream()
-                .map(rp -> {
-                    Ride ride = rp.getRide();
-                    Post post = postRepository.findByIdAndDeletedFalse(ride.getPostId()).orElse(null);
-                    return RideResponse.from(ride, post);
-                })
+        List<RidePassenger> ridePassengers =
+                ridePassengerRepository.findAllByPassengerIdWithRideOrderByCreatedAtDesc(passengerId);
+        Set<Long> postIds = ridePassengers.stream()
+                .map(rp -> rp.getRide().getPostId())
+                .collect(Collectors.toSet());
+        Map<Long, Post> postMap = postRepository.findAllById(postIds).stream()
+                .collect(Collectors.toMap(Post::getId, p -> p));
+        return ridePassengers.stream()
+                .map(rp -> RideResponse.from(rp.getRide(), postMap.get(rp.getRide().getPostId())))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 관련 이슈
closes #132

## 변경 요약

보안 취약점 1건과 신뢰성 문제 3건을 수정합니다.

---

### 1. [심각] IDOR 차단 — `MemberController`

**문제:** `GET /api/v1/members/{id}` 인증만 필요하고 본인 확인 없어 타인의 이메일/프로필 조회 가능.

**수정:**
```java
@GetMapping("/{id}")
public ResponseEntity<?> getProfileById(@PathVariable Long id, Authentication authentication) {
    Long callerId = (Long) authentication.getPrincipal();
    if (!callerId.equals(id)) {
        throw new CarpoolException(ErrorCode.MEMBER_FORBIDDEN);  // 403
    }
    ...
}
```

---

### 2. Review 중복 저장 Race Condition → 500 수정 — `ReviewCreateService`

**문제:** `existsByRideIdAndReviewerId()` + `save()` Gap에서 동시 요청 시 UniqueConstraint 위반 → 500.

**수정:** `DataIntegrityViolationException` catch → 409 `REVIEW_ALREADY_EXISTS` 반환.

---

### 3. `ApplicationStatusService.accept()` `@Retryable` 추가

**문제:** Post에 Optimistic Lock이 있지만 재시도 없어 수락 충돌 시 409 직접 노출.

**수정:** `@Retryable(ObjectOptimisticLockingFailureException, maxAttempts=3)` 추가.

---

### 4. `RideService` N+1 제거

**문제:**
- `getMyRidesAsDriver`: N개 운행 × Post 쿼리 1회 = N+1
- `getMyRidesAsPassenger`: RidePassenger lazy load N회 + Post N회 = 최대 2N+1

**수정:**
- `RidePassengerRepository`에 `JOIN FETCH rp.ride` 쿼리 메서드 추가
- 두 메서드 모두 postId 배치 수집 후 `findAllById` 한 번으로 교체

---

## 테스트 체크리스트

- [ ] 타인 ID로 `GET /api/v1/members/{id}` 요청 시 403 반환
- [ ] 본인 ID로 `GET /api/v1/members/{id}` 정상 응답
- [ ] 동시 리뷰 등록 시 409 반환 (500 아님)
- [ ] 수락 동시 요청 시 자동 재시도 후 정상 처리
- [ ] 내 운행 목록 조회 쿼리 수 감소 확인