### PR TITLE
chore: 배포 환경 분리 (prod 프로파일 + CI/CD + nginx)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 jobs:
   build:
@@ -90,6 +90,7 @@ jobs:
           cd ~/carpool
           echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env
           echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
+          echo "CORS_ALLOWED_ORIGINS=${{ secrets.CORS_ALLOWED_ORIGINS }}" >> .env
           echo "SPRING_PROFILES_ACTIVE=prod" >> .env
-          docker compose pull app
-          docker compose up -d --no-build
+          docker compose -f docker-compose.prod.yml pull app
+          docker compose -f docker-compose.prod.yml up -d --no-build

--- a/backend/src/main/java/com/techeer/carpool/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/auth/controller/AuthController.java
@@ -46,6 +46,9 @@ public class AuthController {
     @Value("${jwt.cookie-secure}")
     private boolean cookieSecure;
 
+    @Value("${jwt.cookie-samesite:Strict}")
+    private String cookieSameSite;
+
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupRequest request) {
         memberSignupService.signup(request);
@@ -89,7 +92,7 @@ public class AuthController {
         ResponseCookie deleteCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
                 .maxAge(0)
                 .httpOnly(true)
-                .sameSite("Strict")
+                .sameSite(cookieSameSite)
                 .path("/api/v1/auth")
                 .secure(cookieSecure)
                 .build();
@@ -109,7 +112,7 @@ public class AuthController {
     private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
                 .httpOnly(true)
-                .sameSite("Strict")
+                .sameSite(cookieSameSite)
                 .secure(cookieSecure)
                 .path("/api/v1/auth")
                 .maxAge(jwtTokenProvider.getRefreshTokenExpirationSeconds())

--- a/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import org.springframework.beans.factory.annotation.Value;
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
@@ -62,12 +63,21 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(allowedOrigin));
+        // 콤마로 구분된 다중 origin 허용. allowCredentials(true)와 함께 쓰려면
+        // setAllowedOrigins 대신 패턴 기반 API 사용 (Vercel 프리뷰 https://*.vercel.app 지원)
+        config.setAllowedOriginPatterns(parseOrigins(allowedOrigin));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
+    }
+
+    private List<String> parseOrigins(String origins) {
+        return Arrays.stream(origins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 }

--- a/backend/src/main/java/com/techeer/carpool/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/techeer/carpool/global/config/WebSocketConfig.java
@@ -9,6 +9,8 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import java.util.Arrays;
+
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
@@ -27,7 +29,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").setAllowedOriginPatterns(allowedOrigin);
+        // 콤마 구분 다중 origin 허용 (Vercel 도메인 + 프리뷰 패턴)
+        String[] origins = Arrays.stream(allowedOrigin.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toArray(String[]::new);
+        registry.addEndpoint("/ws").setAllowedOriginPatterns(origins);
     }
 
     @Override

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,26 @@
+# =============================================
+# 프로덕션(EC2 배포) 프로파일
+# 활성화: SPRING_PROFILES_ACTIVE=prod
+# 환경변수는 docker compose .env 에서 주입됩니다.
+# =============================================
+server:
+  tomcat:
+    threads:
+      max: 400
+
+spring:
+  main:
+    lazy-initialization: true
+  datasource:
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 5
+      connection-timeout: 10000
+  jpa:
+    hibernate:
+      ddl-auto: validate   # 운영 안전: 스키마 변경 금지(검증만). update는 데이터 손실 위험
+    show-sql: false
+
+jwt:
+  cookie-secure: true      # HTTPS 전제 (nginx + Let's Encrypt)
+  cookie-samesite: None    # Vercel(프론트) ↔ EC2(백엔드) cross-site 쿠키 전송 허용

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,6 +24,7 @@ jwt:
   access-token-expiration: 900000      # 15분
   refresh-token-expiration: 604800000  # 7일
   cookie-secure: true
+  cookie-samesite: Strict              # 기본 same-origin 환경용. prod(cross-site)에서는 None 으로 override
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,68 @@
+# =============================================
+# 프로덕션(EC2) 전용 compose
+# - 모니터링(Prometheus/Grafana) 및 k6 미포함 (prod 경량화)
+# - nginx만 외부 노출(80/443), app/db/redis는 내부 네트워크 전용
+# - 환경변수는 같은 디렉터리의 .env 에서 주입 (CD가 생성)
+# 사용: docker compose -f docker-compose.prod.yml up -d
+# =============================================
+services:
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: carpool-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - ./nginx/certbot-www:/var/www/certbot
+    depends_on:
+      - app
+    restart: unless-stopped
+
+  app:
+    image: ${DOCKER_USERNAME}/carpool:latest
+    container_name: carpool-app
+    expose:
+      - "8080"                       # 내부 네트워크 전용 (외부 미공개)
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
+      DB_URL: jdbc:postgresql://db:5432/carpool
+      DB_USERNAME: ${DB_USERNAME:-user}
+      DB_PASSWORD: ${DB_PASSWORD:-password}
+      REDIS_HOST: redis
+      JWT_SECRET: ${JWT_SECRET}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      JAVA_TOOL_OPTIONS: "-Xmx384m -Xms128m"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512m
+
+  db:
+    image: postgres:15
+    container_name: carpool-db
+    environment:
+      POSTGRES_USER: ${DB_USERNAME:-user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-password}
+      POSTGRES_DB: carpool
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data   # 컨테이너가 꺼져도 데이터 보존
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-user} -d carpool"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: carpool-redis
+    restart: unless-stopped

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,59 @@
+# =============================================
+# nginx 리버스 프록시 (EC2)
+# 역할: TLS 종단 + /api·/ws 를 백엔드 컨테이너(app:8080)로 프록시
+# 프론트는 Vercel에서 서빙하므로 정적 파일 서빙은 하지 않음.
+# ⚠️ server_name 의 도메인은 실제 DuckDNS 서브도메인으로 교체하세요.
+# =============================================
+
+# HTTP(80): certbot 갱신용 webroot + HTTPS 리다이렉트
+server {
+    listen 80;
+    server_name carpool-api.duckdns.org;
+
+    # Let's Encrypt 인증서 갱신(HTTP-01 challenge)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS(443): API + WebSocket 프록시
+server {
+    listen 443 ssl;
+    server_name carpool-api.duckdns.org;
+
+    ssl_certificate     /etc/letsencrypt/live/carpool-api.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/carpool-api.duckdns.org/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    # REST API
+    location /api/ {
+        proxy_pass http://app:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket (STOMP) — Upgrade 헤더 필수
+    location /ws {
+        proxy_pass http://app:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 3600s;   # 장시간 연결 유지
+    }
+
+    # 헬스체크(선택)
+    location = /actuator/health {
+        proxy_pass http://app:8080;
+        proxy_set_header Host $host;
+    }
+}


### PR DESCRIPTION
## 개요
Vercel(프론트) + AWS EC2(백엔드) 배포를 위한 prod 환경 분리 및 CI/CD 보강.

## 변경 사항
- `application-prod.yml` 신규: ddl-auto=validate, cookie-secure=true, cookie-samesite=None
- AuthController 리프레시 쿠키 SameSite 프로파일화 (cross-site refresh 대응)
- CORS/WebSocket origin 콤마 다중 + `*.vercel.app` 패턴 허용
- `docker-compose.prod.yml` 신규: 모니터링/k6 미포함, app은 image 사용, app/db/redis 외부포트 비공개
- `gradle.yml` CD 보강: prod compose 사용 + CORS_ALLOWED_ORIGINS 주입, PR 트리거에 develop 추가
- `nginx/nginx.conf` 신규: TLS 종단 + /api·/ws 프록시

## ⚠️ 머지 시 주의
deploy job은 GitHub Secrets(EC2_HOST, EC2_SSH_KEY, DOCKER_*, JWT_SECRET, CORS_ALLOWED_ORIGINS)와 EC2가 준비돼야 성공함.