### PR TITLE
ci: deploy app force-recreate (CD 갱신 신뢰성)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -94,3 +94,5 @@ jobs:
           echo "SPRING_PROFILES_ACTIVE=prod" >> .env
           docker compose -f docker-compose.prod.yml pull app
           docker compose -f docker-compose.prod.yml up -d --no-build
+          # app은 새 이미지로 확실히 교체 (옛 컨테이너 재사용 방지)
+          docker compose -f docker-compose.prod.yml up -d --no-build --force-recreate --no-deps app


### PR DESCRIPTION
deploy 시 app 컨테이너를 force-recreate 하여 옛 컨테이너 재사용으로 새 이미지가 반영 안 되던 문제 방지. 이 PR 머지로 CD end-to-end 동작 검증.