### PR TITLE
fix: 위치 hot path 메시지당 DB 조회/트랜잭션 제거 (#140)

### DIFF
--- a/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideLocationRedisRepository.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/repository/RideLocationRedisRepository.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 public class RideLocationRedisRepository {
 
     private static final String KEY_PREFIX = "ride:route:";
+    private static final String DRIVER_KEY_PREFIX = "ride:driver:";
     private static final Duration TTL = Duration.ofHours(24);
 
     private final StringRedisTemplate stringRedisTemplate;
@@ -59,8 +60,26 @@ public class RideLocationRedisRepository {
         stringRedisTemplate.delete(key(rideId));
     }
 
+    // 위치 hot path 검증용 rideId -> driverId 캐시 (운행 중 불변값이라 메시지마다 DB 조회 대신 사용)
+    public void cacheDriver(Long rideId, Long driverId) {
+        stringRedisTemplate.opsForValue().set(driverKey(rideId), String.valueOf(driverId), TTL);
+    }
+
+    public Long getCachedDriver(Long rideId) {
+        String value = stringRedisTemplate.opsForValue().get(driverKey(rideId));
+        return value == null ? null : Long.valueOf(value);
+    }
+
+    public void evictDriver(Long rideId) {
+        stringRedisTemplate.delete(driverKey(rideId));
+    }
+
     private String key(Long rideId) {
         return KEY_PREFIX + rideId;
+    }
+
+    private String driverKey(Long rideId) {
+        return DRIVER_KEY_PREFIX + rideId;
     }
 
     private String serialize(RideLocationEntry entry) {

--- a/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
+++ b/backend/src/main/java/com/techeer/carpool/domain/ride/service/RideService.java
@@ -28,6 +28,7 @@ import com.techeer.carpool.global.exception.ErrorCode;
 import com.techeer.carpool.global.metrics.CarpoolMetrics;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -96,6 +97,8 @@ public class RideService {
         validateDriver(ride, requesterId);
         ride.start();
         carpoolMetrics.incrementRideStarted();
+        // 위치 hot path 검증용 driverId 캐시 적재 (메시지마다 DB 조회 제거)
+        rideLocationRedisRepository.cacheDriver(rideId, ride.getDriverId());
 
         List<Long> passengerIds = ride.getPassengers().stream()
                 .map(RidePassenger::getPassengerId)
@@ -133,6 +136,7 @@ public class RideService {
             @Override
             public void afterCommit() {
                 rideLocationRedisRepository.delete(rideId);
+                rideLocationRedisRepository.evictDriver(rideId);
             }
         });
 
@@ -152,10 +156,19 @@ public class RideService {
         return RideResponse.from(ride, post);
     }
 
+    // 위치 전송은 초당 수천 건 호출되는 hot path. 메시지마다 트랜잭션/커넥션을 점유하지 않도록
+    // SUPPORTS로 두고(없으면 트랜잭션 미생성), 드라이버 검증은 Redis 캐시로 처리해 DB 조회를 제거한다.
+    @Transactional(propagation = Propagation.SUPPORTS)
     public void updateLocationDirect(Long rideId, Double latitude, Double longitude, Long requesterId) {
-        Ride ride = rideRepository.findById(rideId).orElse(null);
-        if (ride == null || !ride.getDriverId().equals(requesterId)) return;
-        if (ride.getStatus() == RideStatus.COMPLETED) return;
+        Long driverId = rideLocationRedisRepository.getCachedDriver(rideId);
+        if (driverId == null) {
+            // 캐시 미스(운행 시작 전 적재 누락/캐시 만료 등): DB fallback 후 재적재
+            Ride ride = rideRepository.findById(rideId).orElse(null);
+            if (ride == null || ride.getStatus() == RideStatus.COMPLETED) return;
+            driverId = ride.getDriverId();
+            rideLocationRedisRepository.cacheDriver(rideId, driverId);
+        }
+        if (!driverId.equals(requesterId)) return;
         // DB 직접 저장 대신 Redis List에 append (Write-Behind)
         rideLocationRedisRepository.push(rideId, latitude, longitude);
         carpoolMetrics.incrementLocationUpdated();


### PR DESCRIPTION
Closes #140

위치 전송 hot path(`updateLocationDirect`)에서 메시지마다 발생하던 `findById` DB SELECT + readOnly 트랜잭션 커넥션 점유를 제거.

- 운행 시작 시 `rideId→driverId` Redis 캐시 적재
- hot path는 캐시로 검증, 캐시 미스만 DB fallback
- `@Transactional(propagation=SUPPORTS)`로 불필요 트랜잭션 제거
- 운행 종료 시 캐시 evict

컴파일 확인 완료.