### PR TITLE
위치공유 병목 측정(HikariCP)·saturation curve·Grafana 패널

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ replay_pid*
 postgres_data/
 # k6 성능 비교 결과 파일
 k6/results/
+
+# IDE / 로컬 도구
+.idea/
+.claude/

--- a/grafana/provisioning/dashboards/carpool-business.json
+++ b/grafana/provisioning/dashboards/carpool-business.json
@@ -246,6 +246,75 @@
       ],
       "title": "Redis 응답시간 p95",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "pending(대기 스레드)" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "max(=30)" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "id": 9,
+      "targets": [
+        {
+          "expr": "hikaricp_connections_pending{application=\"carpool\"}",
+          "legendFormat": "pending(대기 스레드)",
+          "refId": "A"
+        },
+        {
+          "expr": "hikaricp_connections_active{application=\"carpool\"}",
+          "legendFormat": "active",
+          "refId": "B"
+        },
+        {
+          "expr": "hikaricp_connections_max{application=\"carpool\"}",
+          "legendFormat": "max(=30)",
+          "refId": "C"
+        }
+      ],
+      "title": "HikariCP 대기 스레드 (pending) — 커넥션 풀 포화 지표",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "획득 타임아웃/초" },
+            "properties": [
+              { "id": "unit", "value": "ops" },
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "id": 10,
+      "targets": [
+        {
+          "expr": "rate(hikaricp_connections_acquire_seconds_sum{application=\"carpool\"}[1m]) / clamp_min(rate(hikaricp_connections_acquire_seconds_count{application=\"carpool\"}[1m]), 0.001)",
+          "legendFormat": "커넥션 획득 평균 대기",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(hikaricp_connections_timeout_total{application=\"carpool\"}[1m])",
+          "legendFormat": "획득 타임아웃/초",
+          "refId": "B"
+        }
+      ],
+      "title": "HikariCP 커넥션 획득 대기 & 타임아웃",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/k6/run_journey.sh
+++ b/k6/run_journey.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Redis 3단계 도입기 측정 (small 2cpu/2g). DB INSERT → Write-Behind → 인가 Redis 캐시.
+# 부하: 06b_sat.js (SCALE=100, interval=10ms ≈ offered 10k/s) — DB 병목을 드러내는 적당한 포화.
+set -u
+ROOT=/home/pjj1122/Projects/carpool/Backend; cd "$ROOT"
+PROM=http://localhost:8080/actuator/prometheus
+CF="docker-compose.yml:docker-compose.small.yml"
+RES="$ROOT/k6/results/journey"; mkdir -p "$RES"; SUM="$RES/summary.txt"; : > "$SUM"
+ctr(){ curl -s "$PROM" 2>/dev/null | awk '/^carpool_location_updates_total\{/{print $2}'; }
+# HikariCP 스냅: active pending acquire_sum acquire_count timeout (병목 증명용)
+hk(){ curl -s "$PROM" 2>/dev/null | awk '
+  /^hikaricp_connections_active\{/{a=$2}
+  /^hikaricp_connections_pending\{/{p=$2}
+  /^hikaricp_connections_acquire_seconds_sum/{s=$2}
+  /^hikaricp_connections_acquire_seconds_count/{c=$2}
+  /^hikaricp_connections_timeout_total/{t=$2}
+  END{printf "%s %s %s %s %s", a+0,p+0,s+0,c+0,t+0}'; }
+
+measure(){ # branch label
+  local br=$1 label=$2 out="$RES/$2"; mkdir -p "$out"
+  echo "== [$label] $br ==" | tee -a "$SUM"
+  git checkout "$br" -q
+  COMPOSE_FILE="$CF" docker compose build app >"$out/build.log" 2>&1 || { echo "$label BUILD_FAIL"|tee -a "$SUM"; return; }
+  COMPOSE_FILE="$CF" docker compose up -d --force-recreate app >>"$out/build.log" 2>&1
+  local ok=0; for i in $(seq 1 60); do [ "$(curl -s -o /dev/null -w '%{http_code}' $PROM 2>/dev/null)" = 200 ] && { ok=1; break; }; sleep 2; done
+  [ $ok = 1 ] || { echo "$label NOT_READY"|tee -a "$SUM"; return; }
+  docker exec carpool-redis redis-cli FLUSHALL >/dev/null 2>&1
+  docker exec carpool-db psql -U user -d carpool -c "TRUNCATE ride_locations" >/dev/null 2>&1
+  sleep 3
+  local idle=$(docker stats --no-stream --format '{{.MemUsage}}' carpool-app | grep -oE '^[0-9.]+')
+  ( while true; do
+      m=$(docker stats --no-stream --format '{{.MemUsage}}' carpool-app 2>/dev/null | grep -oE '^[0-9.]+')
+      echo "$m|$(ctr)|$(hk)"; sleep 2
+    done ) >"$out/series.log" 2>/dev/null & local sp=$!
+  k6 run -e SCALE=100 -e SEND_INTERVAL_MS=10 -e FLOOD_SEC=40 k6/scenarios/06b_sat.js >"$out/k6.log" 2>&1
+  kill "$sp" 2>/dev/null; sleep 1
+  local pm=$(awk -F'|' '$1!=""{print $1}' "$out/series.log" | sort -n | tail -1)
+  local tps=$(awk -F'|' '$2!=""{c[++n]=$2} END{best=0;for(i=1;i+5<=n;i++){d=(c[i+5]-c[i])/10;if(d>best)best=d}printf "%.0f",best}' "$out/series.log")
+  local p95=$(grep ws_connect_duration "$out/k6.log" | grep -oE 'p\(95\)=[0-9.]+' | tail -1 | cut -d= -f2)
+  local rows=$(docker exec carpool-db psql -U user -d carpool -tAc "SELECT count(*) FROM ride_locations" 2>/dev/null)
+  # HikariCP 병목 지표: 3번째 필드(공백구분 a p s c t)에서 peak active/pending, acquire 평균대기(Δsum/Δcount), timeout Δ
+  local hkstat=$(awk -F'|' '$3!=""{split($3,h," "); a=h[1];p=h[2];s=h[3];c=h[4];t=h[5];
+      if(a>amax)amax=a; if(p>pmax)pmax=p;
+      if(s0=="" ){s0=s;c0=c;t0=t}; s1=s;c1=c;t1=t}
+    END{dc=c1-c0; acq=(dc>0)?(s1-s0)/dc*1000:0;
+      printf "active_peak=%d pending_peak=%d acq_avg=%.3fms timeout_delta=%d", amax,pmax,acq,t1-t0}' "$out/series.log")
+  echo "$label | server_tps=$tps | $hkstat | connect_p95=${p95}ms | peak_mem=${pm}MiB | idle_mem=${idle}MiB | db_rows=$rows" | tee -a "$SUM"
+}
+
+measure exp/redis-s1 1-db-insert
+measure exp/redis-s2 2-write-behind
+measure develop      3-auth-cache
+git checkout develop -q
+echo "JOURNEY DONE" | tee -a "$SUM"

--- a/k6/run_sat_curve.sh
+++ b/k6/run_sat_curve.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Saturation curve: offered rate를 올려가며(2k→~16k) 단계별 처리량 천장(knee)을 찾는다.
+# SCALE=100 고정(연결 수 고정) + SEND_INTERVAL_MS만 줄여 offered rate만 변화시킴.
+# offered ≈ SCALE * 1000 / INTERVAL. 측정: carpool_location_updates_total 델타 = server_tps.
+# 대상 3단계: exp/redis-s1(DB INSERT) · exp/redis-s2(Write-Behind+DB인가) · develop(Redis인가)
+set -u
+ROOT=/home/pjj1122/Projects/carpool/Backend; cd "$ROOT"
+PROM=http://localhost:8080/actuator/prometheus
+CF="docker-compose.yml:docker-compose.small.yml"
+SCALE=100
+FLOOD="${FLOOD:-40}"
+INTERVALS=(50 33 25 20 14 10 8 6)   # offered ≈ 2k 3k 4k 5k 7.1k 10k 12.5k 16.7k
+RES="$ROOT/k6/results/curve"; mkdir -p "$RES"
+CSV="$RES/curve.csv"; echo "branch,interval_ms,offered_msgs,server_tps,pending_peak,active_peak,connect_p95_ms" > "$CSV"
+
+ctr(){ curl -s "$PROM" 2>/dev/null | awk '/^carpool_location_updates_total\{/{print $2}'; }
+hk(){ curl -s "$PROM" 2>/dev/null | awk '
+  /^hikaricp_connections_active\{/{a=$2}
+  /^hikaricp_connections_pending\{/{p=$2}
+  END{printf "%s %s", a+0,p+0}'; }
+
+run_point(){ # branch label interval
+  local br=$1 label=$2 iv=$3 out="$RES/$label/iv${iv}"; mkdir -p "$out"
+  local offered=$(( SCALE * 1000 / iv ))
+  docker exec carpool-redis redis-cli FLUSHALL >/dev/null 2>&1
+  docker exec carpool-db psql -U user -d carpool -c "TRUNCATE ride_locations" >/dev/null 2>&1
+  sleep 2
+  # HikariCP peak 샘플러
+  ( while true; do echo "$(hk)"; sleep 1; done ) >"$out/hk.log" 2>/dev/null & local hp=$!
+  k6 run -e SCALE=$SCALE -e SEND_INTERVAL_MS=$iv -e FLOOD_SEC=$FLOOD k6/scenarios/06b_sat.js >"$out/k6.log" 2>&1 &
+  local k6pid=$!
+  sleep 8
+  local msec=$(( FLOOD > 30 ? 30 : FLOOD/2 ))
+  # 처리량이 실제로 오르기 시작할 때까지 대기
+  for w in $(seq 1 30); do a=$(ctr); sleep 1; b=$(ctr); awk "BEGIN{exit !( (${b:-0})-(${a:-0}) > 50 )}" && break; done
+  local t0=$(ctr) ts0=$(date +%s)
+  sleep $msec
+  local t1=$(ctr) ts1=$(date +%s)
+  wait "$k6pid" 2>/dev/null; kill "$hp" 2>/dev/null
+  local el=$(( ts1 - ts0 ))
+  local tps=$(awk "BEGIN{printf \"%.0f\", (${t1:-0}-${t0:-0})/$el}")
+  local apeak=$(awk '{if($1>a)a=$1}END{print a+0}' "$out/hk.log")
+  local ppeak=$(awk '{if($2>p)p=$2}END{print p+0}' "$out/hk.log")
+  local p95=$(grep ws_connect_duration "$out/k6.log" | grep -oE 'p\(95\)=[0-9.]+' | tail -1 | cut -d= -f2)
+  echo "$br,$iv,$offered,$tps,$ppeak,$apeak,${p95:-}" | tee -a "$CSV"
+}
+
+measure_branch(){ # branch label
+  local br=$1 label=$2
+  echo "== curve [$label] $br =="
+  git checkout "$br" -q || { echo "$label CHECKOUT_FAIL"; return; }
+  COMPOSE_FILE="$CF" docker compose build app >"$RES/$label-build.log" 2>&1 || { echo "$label BUILD_FAIL"; return; }
+  COMPOSE_FILE="$CF" docker compose up -d --force-recreate app >>"$RES/$label-build.log" 2>&1
+  local ok=0; for i in $(seq 1 60); do [ "$(curl -s -o /dev/null -w '%{http_code}' $PROM 2>/dev/null)" = 200 ] && { ok=1; break; }; sleep 2; done
+  [ $ok = 1 ] || { echo "$label NOT_READY"; return; }
+  sleep 3
+  for iv in "${INTERVALS[@]}"; do run_point "$br" "$label" "$iv"; done
+}
+
+measure_branch exp/redis-s1 1-db-insert
+measure_branch exp/redis-s2 2-write-behind
+measure_branch develop      3-auth-cache
+git checkout develop -q
+echo "CURVE DONE -> $CSV"
+column -t -s, "$CSV"

--- a/k6/scenarios/06b_sat.js
+++ b/k6/scenarios/06b_sat.js
@@ -1,0 +1,80 @@
+// 포화(saturation) 벤치마크 — inbound 채널을 의도적으로 포화시켜 스레드 모델별 "처리량 천장"을 비교.
+// 실제 GPS(1초 간격)와 달리 전송 간격을 SEND_INTERVAL_MS로 확 줄여 메시지를 쏟아붓는다.
+// 성능 기준은 서버 메트릭 carpool_location_updates_total(실제 처리 수)로 측정한다.
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+import { randomDriverPayload, randomPostPayload, randomLocation, stompConnectFrame, stompSendLocationFrame } from '../utils/data.js';
+import { BASE_URL, WS_URL, authHeaders } from '../utils/auth.js';
+
+const SCALE      = parseInt(__ENV.SCALE) || 100;
+const INTERVAL   = parseInt(__ENV.SEND_INTERVAL_MS) || 20;   // ms — 작을수록 포화
+const FLOOD_SEC  = parseInt(__ENV.FLOOD_SEC) || 60;
+const POOL_SIZE  = Math.min(SCALE, 100);
+
+export const options = {
+    scenarios: { sat: { executor: 'constant-vus', vus: SCALE, duration: `${FLOOD_SEC}s` } },
+    thresholds: {},  // 포화 벤치마크 — pass/fail 아님
+};
+
+const wsConnectDuration = new Trend('ws_connect_duration');
+const clientSent        = new Counter('client_sent');
+const sendErrors        = new Counter('send_errors');
+
+export function setup() {
+    const password = 'password1234';
+    const ts = Date.now();
+    const pool = [];
+    console.log(`[sat] 드라이버 풀 ${POOL_SIZE}개 생성 (SCALE=${SCALE}, interval=${INTERVAL}ms)`);
+    for (let i = 0; i < POOL_SIZE; i++) {
+        const email = `sat_driver_${i}_${ts}@test.com`;
+        http.post(`${BASE_URL}/api/v1/auth/signup`,
+            JSON.stringify({ email, password, nickname: `sat_driver_${i}_${ts}` }),
+            { headers: { 'Content-Type': 'application/json' } });
+        const loginRes = http.post(`${BASE_URL}/api/v1/auth/login`,
+            JSON.stringify({ email, password }), { headers: { 'Content-Type': 'application/json' } });
+        if (loginRes.status !== 200) continue;
+        const token = loginRes.json('data.accessToken');
+        const hdr = authHeaders(token);
+        http.post(`${BASE_URL}/api/v1/drivers`, JSON.stringify(randomDriverPayload()), hdr);
+        const postRes = http.post(`${BASE_URL}/api/v1/posts`, JSON.stringify(randomPostPayload(120)), hdr);
+        if (postRes.status !== 201) continue;
+        const postId = postRes.json('data.id');
+        const rideRes = http.post(`${BASE_URL}/api/v1/rides`, JSON.stringify({ postId }), hdr);
+        if (rideRes.status !== 201) continue;
+        const rideId = rideRes.json('data.id');
+        const startRes = http.post(`${BASE_URL}/api/v1/rides/${rideId}/start`, null, hdr);
+        if (startRes.status !== 200) continue;
+        pool.push({ token, rideId });
+        sleep(0.01);
+    }
+    console.log(`[sat] setup 완료: 풀 ${pool.length}개`);
+    return { pool };
+}
+
+export default function (data) {
+    const { pool } = data;
+    if (!pool || pool.length === 0) return;
+    const { token, rideId } = pool[(__VU - 1) % pool.length];
+    const startMs = Date.now();
+    ws.connect(WS_URL, { headers: { 'Authorization': `Bearer ${token}` } }, function (socket) {
+        let connected = false;
+        socket.on('open', () => socket.send(stompConnectFrame(token)));
+        socket.on('message', (msg) => {
+            if (msg.startsWith('CONNECTED') && !connected) {
+                connected = true;
+                wsConnectDuration.add(Date.now() - startMs);
+                socket.setInterval(() => {
+                    try {
+                        const { latitude, longitude } = randomLocation(37.5, 127.0);
+                        socket.send(stompSendLocationFrame(rideId, latitude, longitude));
+                        clientSent.add(1);
+                    } catch (e) { sendErrors.add(1); }
+                }, INTERVAL);
+            }
+        });
+        socket.on('error', () => sendErrors.add(1));
+        socket.setTimeout(() => socket.close(), (FLOOD_SEC - 2) * 1000);
+    });
+}


### PR DESCRIPTION
## 요약
실시간 위치공유 고도화 도입기(노션)의 "②→③ 처리량 2배 점프 = HikariCP 커넥션 30개 포화 해소" 주장을 메트릭으로 입증하고, 처리량 천장 곡선을 측정.

## 변경
- `k6/run_journey.sh`: 3단계 비교에 HikariCP active/pending/획득대기/timeout 캡처 추가 (+ 테이블명 버그 ride_location→ride_locations)
- `k6/run_sat_curve.sh` (신규): offered 2k~16.7k saturation curve 측정
- `k6/scenarios/06b_sat.js`: 위 스크립트가 쓰는 포화 부하 시나리오
- Grafana `carpool-business.json`: HikariCP pending / 획득대기·timeout 패널 2개 추가
- `.gitignore`: .idea/, .claude/ 추가

## 측정 결과 (small 2vCPU/2GB, offered~10k, 40s)
| 단계 | server_tps | active | pending | 획득대기 |
|---|---|---|---|---|
| ① DB INSERT+DB인가 | 5,020 | 30 | 370 | 119.6ms |
| ② Write-Behind+DB인가 | 5,243 | 30 | 370 | 128.9ms |
| ③ Redis인가 | 12,528 | 1 | 0 | 0.009ms |

②→③에서 pending 370→0, 획득대기 129ms→0.009ms로 커넥션 병목 해소 입증. Saturation 천장: ①~3.1k · ②~4.5k · ③~7.9k.